### PR TITLE
cleanups + partial context k/v cache fix

### DIFF
--- a/amago/envs/amago_env.py
+++ b/amago/envs/amago_env.py
@@ -88,6 +88,7 @@ class AMAGOEnv(gym.Wrapper, ABC):
             reset=True,
             real_reward=None,
             terminal=False,
+            raw_time_idx=0,
         )
         return timestep
 
@@ -133,6 +134,7 @@ class AMAGOEnv(gym.Wrapper, ABC):
             time=float(self.step_count) / self.horizon,
             reset=soft_done,
             real_reward=real_reward,
+            raw_time_idx=self.step_count,
         )
 
         # meta-termination (triggers resets of this environment,

--- a/amago/utils.py
+++ b/amago/utils.py
@@ -28,6 +28,9 @@ def init_plt():
 
 
 def q_curve_plot(loss_info: dict, num_curves: int = 3) -> wandb.Image:
+    """ "
+    Creates a figure of the Q-value across the timesteps of a trajectory.
+    """
     q_seq_keys = sorted([k for k in loss_info.keys() if "q_seq_mean" in k])
     q_std_keys = sorted([k for k in loss_info.keys() if "q_seq_std" in k])
 

--- a/examples/02_popgym_suite.py
+++ b/examples/02_popgym_suite.py
@@ -9,6 +9,8 @@ from example_utils import *
 
 def add_cli(parser):
     parser.add_argument("--env", type=str, default="AutoencodeEasy")
+    parser.add_argument("--max_seq_len", type=int, default=2000)
+    parser.add_argument("--traj_save_len", type=int, default=2000)
     parser.add_argument("--naive", action="store_true")
     return parser
 
@@ -47,8 +49,8 @@ if __name__ == "__main__":
             make_val_env=make_train_env,
             # For this one script to work across every environment,
             # these are arbitrary sequence limits we'll never each.
-            max_seq_len=2000,
-            traj_save_len=2000,
+            max_seq_len=args.max_seq_len,
+            traj_save_len=args.traj_save_len,
             group_name=group_name,
             run_name=run_name,
             val_timesteps_per_epoch=2000,


### PR DESCRIPTION
Looks like a big change but actually only patches key/value caching for *partial* context (max_seq_len << horizon) policies by refactoring the position embedding index logic.