### PR TITLE
Logging Cleanups, CPU Inference 

### DIFF
--- a/amago/cli_utils.py
+++ b/amago/cli_utils.py
@@ -17,7 +17,9 @@ def add_common_cli(parser: ArgumentParser) -> ArgumentParser:
     )
     # basics
     parser.add_argument("--trials", type=int, default=1)
-    parser.add_argument("--gpu", type=int, default=0)
+    parser.add_argument(
+        "--gpu", type=int, default=0, help="GPU Device ID. Use -1 for CPU"
+    )
     parser.add_argument(
         "--no_async",
         action="store_true",

--- a/amago/cli_utils.py
+++ b/amago/cli_utils.py
@@ -133,7 +133,7 @@ Switch between the most common configurations without needing `.gin` config file
 """
 
 
-def switch_tstep_encoder(config : dict, arch: str, **kwargs):
+def switch_tstep_encoder(config: dict, arch: str, **kwargs):
     """
     Convenient way to switch between TstepEncoders without gin config files
 
@@ -269,7 +269,7 @@ def create_experiment_from_cli(
     traj_save_len: int,
     group_name: str,
     run_name: str,
-    experiment_Cls = amago.Experiment,
+    experiment_Cls=amago.Experiment,
     **extra_experiment_kwargs,
 ):
     cli = command_line_args

--- a/amago/learning.py
+++ b/amago/learning.py
@@ -89,7 +89,7 @@ class Experiment:
     sample_actions: bool = True
 
     def start(self):
-        self.DEVICE = torch.device(f"cuda:{self.gpu}")
+        self.DEVICE = torch.device(f"cuda:{self.gpu}" if self.gpu >= 0 else "cpu")
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             self.init_envs()

--- a/amago/learning.py
+++ b/amago/learning.py
@@ -203,7 +203,9 @@ class Experiment:
         else:
             ckpt_name = f"{self.run_name}_BEST.pt"
 
-        ckpt = torch.load(os.path.join(self.ckpt_dir, ckpt_name))
+        ckpt = torch.load(
+            os.path.join(self.ckpt_dir, ckpt_name), map_location=self.DEVICE
+        )
         self.policy.load_state_dict(ckpt["model_state"])
         self.optimizer.load_state_dict(ckpt["optimizer_state"])
         self.epoch = ckpt["epoch"]

--- a/examples/00_kshot_frozen_lake.py
+++ b/examples/00_kshot_frozen_lake.py
@@ -3,13 +3,14 @@ import numpy as np
 
 import amago
 from amago.envs.builtin.gym_envs import GymEnv, MetaFrozenLake
-from amago.envs.cli_utils import *
+from amago.cli_utils import *
 
 
 def add_cli(parser):
     parser.add_argument(
         "--experiment",
         choices=["no-memory", "memory-rnn", "memory-transformer"],
+        required=True,
     )
     parser.add_argument("--run_name", type=str, required=True)
     parser.add_argument("--buffer_dir", type=str, required=True)


### PR DESCRIPTION
Simpler models (feedforward, rnn) can be trained/tested on the cpu, but more complicated `TrajEncoders` (like transformer with flash attn, mamba) will throw an error. Those models are super gpu-dependent and I don't expect this to be easily fixable. It'd be possible to load the `TformerTrajEncoder` params on the cpu and redirect the attention computation from `FlashAttention` to `VanillaAttention` in slow inference mode (or fast inference mode if I ever implement that k/v cache). I'll consider this, although I expect the default models in this repo to only keep getting bigger and cpu usage is definitely not the priority. 