### PR TITLE
Alternate Backward

### DIFF
--- a/examples/crafter_pixels_demo.ipynb
+++ b/examples/crafter_pixels_demo.ipynb
@@ -35,6 +35,7 @@
     "\n",
     "import requests\n",
     "from IPython.display import Video, HTML\n",
+    "import torch\n",
     "\n",
     "crafter_example = __import__(\"07_crafter_with_instructions\")\n",
     "import amago\n",
@@ -70,7 +71,7 @@
       "        \t Mode: Fixed Context with Valid Relabeling (Approximate Meta-RL / POMDPs)\n",
       "        \t Half Precision: False\n",
       "        \t Fast Inference: True\n",
-      "        \t Total Parameters: 5,869,226 \n",
+      "        \t Total Parameters: 6,517,894 \n",
       "\n",
       "\n"
      ]
@@ -139,7 +140,18 @@
    "execution_count": 4,
    "id": "ced17261-6be3-4629-934b-0579093c2edc",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_IncompatibleKeys(missing_keys=['maximized_critics.inp_layer.weight', 'maximized_critics.inp_layer.bias', 'maximized_critics.core_layers.0.weight', 'maximized_critics.core_layers.0.bias', 'maximized_critics.output_layer.weight', 'maximized_critics.output_layer.bias'], unexpected_keys=[])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# checkpoint from long pixel-based training run that closely reproduces Appendix C5 Table 2 using the public repo\n",
     "ckpt_link = \"https://utexas.box.com/shared/static/xvkgo02vkp8kn7j80051jbr6224tep9r.pt\"\n",
@@ -150,7 +162,11 @@
     "    f.write(response.content)\n",
     "\n",
     "# load checkpoint\n",
-    "experiment.load_checkpoint(loading_best=True)"
+    "# you would normally load the best checkpoint like this:\n",
+    "# experiment.load_checkpoint(loading_best=True)\n",
+    "# manual workaround for backwards-compatible old checkpoint\n",
+    "ckpt = torch.load(os.path.join(experiment.ckpt_dir, f\"{experiment.run_name}_BEST.pt\"), map_location=experiment.DEVICE)\n",
+    "experiment.policy.load_state_dict(ckpt[\"model_state\"], strict=False)"
    ]
   },
   {
@@ -182,7 +198,25 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "                                         00 [02:49\u001b[0m\r"
+      "Env Interaction:   0%|\u001b[33m                                                                                                \u001b[0m| 0/3500 [00:00<?, ?it/s]\u001b[0m/home/jake/anaconda3/envs/amagoos/lib/python3.10/site-packages/gym/core.py:43: DeprecationWarning: \u001b[33mWARN: The argument mode in render method is deprecated; use render_mode during environment initialization instead.\n",
+      "See here for more information: https://www.gymlibrary.ml/content/api/\u001b[0m\n",
+      "  deprecation(\n",
+      "/home/jake/anaconda3/envs/amagoos/lib/python3.10/site-packages/gym/core.py:43: DeprecationWarning: \u001b[33mWARN: The argument mode in render method is deprecated; use render_mode during environment initialization instead.\n",
+      "See here for more information: https://www.gymlibrary.ml/content/api/\u001b[0m\n",
+      "  deprecation(\n",
+      "/home/jake/anaconda3/envs/amagoos/lib/python3.10/site-packages/gym/core.py:43: DeprecationWarning: \u001b[33mWARN: The argument mode in render method is deprecated; use render_mode during environment initialization instead.\n",
+      "See here for more information: https://www.gymlibrary.ml/content/api/\u001b[0m\n",
+      "  deprecation(\n",
+      "/home/jake/anaconda3/envs/amagoos/lib/python3.10/site-packages/gym/core.py:43: DeprecationWarning: \u001b[33mWARN: The argument mode in render method is deprecated; use render_mode during environment initialization instead.\n",
+      "See here for more information: https://www.gymlibrary.ml/content/api/\u001b[0m\n",
+      "  deprecation(\n",
+      "/home/jake/anaconda3/envs/amagoos/lib/python3.10/site-packages/gym/core.py:43: DeprecationWarning: \u001b[33mWARN: The argument mode in render method is deprecated; use render_mode during environment initialization instead.\n",
+      "See here for more information: https://www.gymlibrary.ml/content/api/\u001b[0m\n",
+      "  deprecation(\n",
+      "/home/jake/anaconda3/envs/amagoos/lib/python3.10/site-packages/gym/core.py:43: DeprecationWarning: \u001b[33mWARN: The argument mode in render method is deprecated; use render_mode during environment initialization instead.\n",
+      "See here for more information: https://www.gymlibrary.ml/content/api/\u001b[0m\n",
+      "  deprecation(\n",
+      "                                                                                                                                               7.06it/s]\u001b[0m\r"
      ]
     },
     {
@@ -191,7 +225,7 @@
      "text": [
       "\n",
       "\n",
-      "Task \"make_stone_pickaxe, collect_coal, travel_40m_40m, place_stone\" Success Rate:  62.6%\n"
+      "Task \"make_stone_pickaxe, collect_coal, travel_40m_40m, place_stone\" Success Rate:  58.0%\n"
      ]
     }
    ],
@@ -212,7 +246,7 @@
     "\n",
     "# runs the evaluation and saves videos to disk\n",
     "warnings.filterwarnings(\"ignore\", category=UserWarning)\n",
-    "success = experiment.evaluate_test(make_eval_env, timesteps=2500, render=False)[\"Average Success Rate in crafter_eval\"]\n",
+    "success = experiment.evaluate_test(make_eval_env, timesteps=3500, render=False)[\"Average Success Rate in crafter_eval\"]\n",
     "print(f\"\\n\\nTask \\\"{', '.join(TASK)}\\\" Success Rate: {success * 100 : .1f}%\")"
    ]
   },
@@ -228,49 +262,49 @@
        "<table><caption style='font-size: 24px'>make_stone_pickaxe, collect_coal, travel_40m_40m, place_stone</caption><tr>\n",
        "    <td>\n",
        "        <video width=300px alt=\"Video\" controls>\n",
-       "            <source src=\"crafter_notebook_videos/20240125T054626-achNone-len77.mp4\" type=\"video/mp4\">\n",
+       "            <source src=\"crafter_notebook_videos/20240213T211855-achNone-len55.mp4\" type=\"video/mp4\">\n",
        "        </video>\n",
        "    </td>\n",
        "    \n",
        "    <td>\n",
        "        <video width=300px alt=\"Video\" controls>\n",
-       "            <source src=\"crafter_notebook_videos/20240125T054536-ach7-len206.mp4\" type=\"video/mp4\">\n",
+       "            <source src=\"crafter_notebook_videos/20240213T211659-ach9-len164.mp4\" type=\"video/mp4\">\n",
        "        </video>\n",
        "    </td>\n",
        "    \n",
        "    <td>\n",
        "        <video width=300px alt=\"Video\" controls>\n",
-       "            <source src=\"crafter_notebook_videos/20240125T054748-achNone-len98.mp4\" type=\"video/mp4\">\n",
+       "            <source src=\"crafter_notebook_videos/20240213T211624-ach6-len203.mp4\" type=\"video/mp4\">\n",
        "        </video>\n",
        "    </td>\n",
        "    \n",
        "    <td>\n",
        "        <video width=300px alt=\"Video\" controls>\n",
-       "            <source src=\"crafter_notebook_videos/20240125T054642-achNone-len69.mp4\" type=\"video/mp4\">\n",
+       "            <source src=\"crafter_notebook_videos/20240213T211601-ach6-len186.mp4\" type=\"video/mp4\">\n",
        "        </video>\n",
        "    </td>\n",
        "    </tr><tr>\n",
        "    <td>\n",
        "        <video width=300px alt=\"Video\" controls>\n",
-       "            <source src=\"crafter_notebook_videos/20240125T054759-ach7-len55.mp4\" type=\"video/mp4\">\n",
+       "            <source src=\"crafter_notebook_videos/20240213T211428-ach6-len162.mp4\" type=\"video/mp4\">\n",
        "        </video>\n",
        "    </td>\n",
        "    \n",
        "    <td>\n",
        "        <video width=300px alt=\"Video\" controls>\n",
-       "            <source src=\"crafter_notebook_videos/20240125T054754-achNone-len81.mp4\" type=\"video/mp4\">\n",
+       "            <source src=\"crafter_notebook_videos/20240213T211859-ach8-len178.mp4\" type=\"video/mp4\">\n",
        "        </video>\n",
        "    </td>\n",
        "    \n",
        "    <td>\n",
        "        <video width=300px alt=\"Video\" controls>\n",
-       "            <source src=\"crafter_notebook_videos/20240125T054733-achNone-len100.mp4\" type=\"video/mp4\">\n",
+       "            <source src=\"crafter_notebook_videos/20240213T211604-ach6-len172.mp4\" type=\"video/mp4\">\n",
        "        </video>\n",
        "    </td>\n",
        "    \n",
        "    <td>\n",
        "        <video width=300px alt=\"Video\" controls>\n",
-       "            <source src=\"crafter_notebook_videos/20240125T054657-achNone-len119.mp4\" type=\"video/mp4\">\n",
+       "            <source src=\"crafter_notebook_videos/20240213T212035-achNone-len163.mp4\" type=\"video/mp4\">\n",
        "        </video>\n",
        "    </td>\n",
        "    </tr><tr></tr></table>"


### PR DESCRIPTION
Welcome to a long note about a niche implementation detail that almost no one cares about and makes no conceptual difference! ...But it was described in the paper and I don't plan on editing it, so I feel like I should be thorough about this somewhere. 

----------------------------


The shared sequence model approach boils down to how we optimize the actor and critic loss functions at the same time. You'd expect this to look something like:

https://github.com/UT-Austin-RPL/amago/blob/db0445957df9dabd1ce9ef78b7d23f6efd1f54ef/amago/learning.py#L574-L585

Where you just add the weighted combo together and take a grad step... and this is how it's been tried before. But since the actor's objective is (at least partially) to maximize the outputs of the critics, the critics would be optimized to maximize their outputs for all action inputs. When this works it's essentially a coincidence caused by learning rates / loss surfaces training the actor faster than the critics. It often doesn't work and leads to noticeably unstable critic grads if you plot that info. The updated version of [Ni et al., 2023](https://arxiv.org/abs/2307.03864) Appendix C1 walks through the math if it's helpful. 

The fix is to remove the gradients of the TD3/REDQ actor loss from the critics' update. I did this by doing the actor loss `backward` first, retaining the graph, zeroing the critic grads manually, then doing the critic loss `backward`:

https://github.com/UT-Austin-RPL/amago/blob/ad3b4ba9db37353224ca034e4129bc762ac9f932/amago/learning.py#L577-L592

This is much faster than doing two separate optimization steps and lets you train the Transformer on the actor's loss instead of detaching (Appendix A1 of the paper). But the half precision scaling gets messy.

AMAGO was a super long project and this fix (and the motivation to use a Transformer in an off-policy actor-critic for memory/meta-RL) is almost 2 years old now. The paper linked above was released between conference (re)submissions. They patch the same problem with Transformers like:

```python
        if self.freeze_critic:
            if self.algo.continuous_action:
                new_joint_q_embeds = torch.cat(
                    (hidden_states.detach(), new_actions), dim=-1
                )  # (T+1, B, dim)
            else:
                new_joint_q_embeds = hidden_states.detach()


            freezed_qf1 = deepcopy(self.qf1).to(ptu.device)
            freezed_qf2 = deepcopy(self.qf2).to(ptu.device)
            q1 = freezed_qf1(new_joint_q_embeds)
            q2 = freezed_qf2(new_joint_q_embeds)
```

Where you remove the critic gradients by duplicating the network, moving it to the GPU, maximizing the outputs of the copy, and skipping the weird `backward` step. This is a lot cleaner, but I left my version as it was... basically just to prove it was concurrent since by this time the off-policy Transformer novelty had taken hit after hit [[AdA](https://arxiv.org/abs/2301.07608), [AD](https://arxiv.org/abs/2210.14215), [Ni](https://arxiv.org/abs/2307.03864)] (not that anyone would have ever noticed or cared).  All of this is just a bug patch, and if the paper had come out when it was originally meant to I would've barley mentioned it. But the two updates should be numerically equivalent, and I've had a colab notebook demo about it in the comments for a few months:

https://github.com/UT-Austin-RPL/amago/blob/ad3b4ba9db37353224ca034e4129bc762ac9f932/amago/learning.py#L568-L576


In my opinion it would be slightly better to route the actor objective to a second "target" critic that happens to have `tau=1.0` (so that it's always the same as the online critic). We'd save the cpu --> gpu memory move above and get a big speedup, *although at current critic scales this is not an important bottleneck*. Maintaining an extra target critic also makes it more obvious that something unusual/important is going on. It creates more unused params at inference time, but that's always true for actor-critics. We now implement this version, which makes the update step look like the first code block above. It should be equivalent to what we've always had, but gets somewhere between a 1.1-1.3x speedup on the example commands.

https://github.com/UT-Austin-RPL/amago/blob/db0445957df9dabd1ce9ef78b7d23f6efd1f54ef/amago/agent.py#L174-L181

https://github.com/UT-Austin-RPL/amago/blob/db0445957df9dabd1ce9ef78b7d23f6efd1f54ef/amago/agent.py#L295

https://github.com/UT-Austin-RPL/amago/blob/db0445957df9dabd1ce9ef78b7d23f6efd1f54ef/amago/agent.py#L364-L366