### PR TITLE
Exploration Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ AMAGO provides a stable way to train long-sequence Transformers with RL, which c
 
 Example on a horizon of 400 timesteps:
 ```bash
-python 09_tmaze.py --no_async --memory_size 128 --memory_layers 2 --parallel_actors 36 --horizon 400 --timesteps_per_epoch 800  --batch_size 18 --grads_per_epoch 600 --dset_max_size 5000 --run_name <str> --buffer_dir <path>
+python 08_tmaze.py --no_async --memory_size 128 --memory_layers 2 --parallel_actors 36 --horizon 400 --timesteps_per_epoch 800  --batch_size 18 --grads_per_epoch 600 --dset_max_size 5000 --run_name <str> --buffer_dir <path>
 ```
 This command with `--horizon 10000 --timesteps_per_epoch 10000` will also train the extreme 10k sequence length mentioned in the paper, although this takes several days to converge due to the inference cost of generating each trajectory.
 </details>

--- a/amago/envs/builtin/babyai.py
+++ b/amago/envs/builtin/babyai.py
@@ -3,7 +3,6 @@ import copy
 import random
 from typing import Iterable, Tuple, List
 
-import minigrid
 import numpy as np
 import gymnasium as gym
 import cv2

--- a/amago/envs/env_utils.py
+++ b/amago/envs/env_utils.py
@@ -226,33 +226,42 @@ class ExplorationWrapper(ABC, gym.ActionWrapper):
 
 
 @gin.configurable
-class EpsilonGreedy(ExplorationWrapper):
+class BilevelEpsilonGreedy(ExplorationWrapper):
+    """
+    Implements the bi-level epsilon greedy exploration strategy visualized in Figure 13
+    of the AMAGO paper. Exploration noise decays both over the course of training and
+    throughout each rollout. This more closely resembles the online exploration/exploitation
+    strategy of a meta-RL agent in a new environment.
+    """
+
     def __init__(
         self,
         env: gym.Env,
-        eps_start_start: float = 1.0,
-        eps_start_end: float = 0.05,
-        eps_end_start: float = 0.8,
-        eps_end_end: float = 0.01,
+        eps_start_start: float = 1.0,  # start of training, start of rollout
+        eps_start_end: float = 0.05,  # end of training, start of rollout
+        eps_end_start: float = 0.8,  # start of training, end of rollout
+        eps_end_end: float = 0.01,  # end of training, end of rollout
         steps_anneal: int = 1_000_000,
     ):
         super().__init__(env)
-
         self.eps_start_start = eps_start_start
         self.eps_start_end = eps_start_end
         self.eps_end_start = eps_end_start
         self.eps_end_end = eps_end_end
-        self.global_slope = (eps_start_start - eps_start_end) / steps_anneal
+
+        self.start_global_slope = (eps_start_start - eps_start_end) / steps_anneal
+        self.end_global_slope = (eps_end_start - eps_end_end) / steps_anneal
         self.discrete = isinstance(self.env.action_space, gym.spaces.Discrete)
         self.global_step = 0
 
     def current_eps(self, local_step: int, horizon: int):
         ep_start = max(
-            self.eps_start_start - self.global_slope * self.global_step,
+            self.eps_start_start - self.start_global_slope * self.global_step,
             self.eps_start_end,
         )
         ep_end = max(
-            self.eps_start_end - self.global_slope * self.global_step, self.eps_end_end
+            self.eps_end_start - self.end_global_slope * self.global_step,
+            self.eps_end_end,
         )
         local_progress = float(local_step) / horizon
         current = self.global_multiplier * (
@@ -279,6 +288,28 @@ class EpsilonGreedy(ExplorationWrapper):
             assert expl_action.dtype == np.float32
         self.global_step += 1
         return expl_action
+
+
+class EpsilonGreedy(BilevelEpsilonGreedy):
+    """
+    Sets the parameters of the BilevelEpsilonGreedy wrapper to be equivalent to standard epsilon-greedy.
+    """
+
+    def __init__(
+        self,
+        env: gym.Env,
+        eps_start: float = 1.0,
+        eps_end: float = 0.05,
+        steps_anneal: int = 1_000_000,
+    ):
+        super().__init__(
+            env,
+            eps_start_start=eps_start,
+            eps_start_end=eps_end,
+            eps_end_start=eps_start,
+            eps_end_end=eps_end,
+            steps_anneal=steps_anneal,
+        )
 
 
 class ReturnHistory:

--- a/amago/envs/env_utils.py
+++ b/amago/envs/env_utils.py
@@ -2,6 +2,7 @@ import os
 import time
 import random
 import warnings
+from abc import ABC, abstractmethod
 from uuid import uuid4
 from dataclasses import dataclass
 from collections import defaultdict
@@ -200,8 +201,32 @@ class GPUSequenceBuffer:
         return torch.Tensor(self.cur_idxs).to(self.device).view(-1, 1, 1).long()
 
 
+class ExplorationWrapper(ABC, gym.ActionWrapper):
+
+    @abstractmethod
+    def add_exploration_noise(self, action: np.ndarray, local_step: int, horizon: int):
+        raise NotImplementedError
+
+    def action(self, a: np.ndarray):
+        return self.add_exploration_noise(a, self.env.step_count, self.env.horizon)
+
+    @property
+    def return_history(self):
+        return self.env.return_history
+
+    @property
+    def success_history(self):
+        return self.env.success_history
+
+    def reset(self, *args, **kwargs):
+        out = super().reset(*args, **kwargs)
+        self.global_multiplier = random.random()
+        np.random.seed(random.randint(0, 1e6))
+        return out
+
+
 @gin.configurable
-class ExplorationWrapper(gym.ActionWrapper):
+class EpsilonGreedy(ExplorationWrapper):
     def __init__(
         self,
         env: gym.Env,
@@ -219,21 +244,7 @@ class ExplorationWrapper(gym.ActionWrapper):
         self.eps_end_end = eps_end_end
         self.global_slope = (eps_start_start - eps_start_end) / steps_anneal
         self.discrete = isinstance(self.env.action_space, gym.spaces.Discrete)
-        self.multibinary = isinstance(self.env.action_space, gym.spaces.MultiBinary)
         self.global_step = 0
-        self.disabled = False
-
-    def turn_off_exploration(self):
-        self.disabled = True
-
-    def turn_on_exploration(self):
-        self.disabled = False
-
-    def reset(self, *args, **kwargs):
-        out = super().reset(*args, **kwargs)
-        self.global_multiplier = random.random()
-        np.random.seed(random.randint(0, 1e6))
-        return out
 
     def current_eps(self, local_step: int, horizon: int):
         ep_start = max(
@@ -249,44 +260,25 @@ class ExplorationWrapper(gym.ActionWrapper):
         )
         return current
 
-    def action(self, a):
-        noise = (
-            self.current_eps(self.env.step_count, self.env.horizon)
-            if not self.disabled
-            else 0.0
-        )
+    def add_exploration_noise(self, action, local_step, horizon):
+        noise = self.current_eps(local_step, horizon)
         if self.discrete:
             # epsilon greedy (DQN-style)
             num_actions = self.env.action_space.n
             random_action = random.randrange(0, num_actions)
             use_random = random.random() <= noise
             if use_random:
-                expl_action = np.full_like(a, random_action)
+                expl_action = np.full_like(action, random_action)
             else:
-                expl_action = a
+                expl_action = action
             assert expl_action.dtype == np.uint8
-        elif self.multibinary:
-            random_actions = np.random.randn(*a.shape) < 0.0
-            use_random = np.random.random(*a.shape) <= noise
-            expl_action = (1 - use_random) * a + use_random * random_actions
-            expl_action = expl_action.astype(np.int8)
         else:
             # random noise (TD3-style)
-            expl_action = a + noise * np.random.randn(*a.shape)
+            expl_action = action + noise * np.random.randn(*action.shape)
             expl_action = np.clip(expl_action, -1.0, 1.0).astype(np.float32)
             assert expl_action.dtype == np.float32
-
-        if not self.disabled:
-            self.global_step += 1
+        self.global_step += 1
         return expl_action
-
-    @property
-    def return_history(self):
-        return self.env.return_history
-
-    @property
-    def success_history(self):
-        return self.env.success_history
 
 
 class ReturnHistory:

--- a/amago/envs/env_utils.py
+++ b/amago/envs/env_utils.py
@@ -253,6 +253,7 @@ class BilevelEpsilonGreedy(ExplorationWrapper):
         self.end_global_slope = (eps_end_start - eps_end_end) / steps_anneal
         self.discrete = isinstance(self.env.action_space, gym.spaces.Discrete)
         self.global_step = 0
+        self.global_multiplier = 1.0
 
     def current_eps(self, local_step: int, horizon: int):
         ep_start = max(

--- a/examples/02_popgym_suite.py
+++ b/examples/02_popgym_suite.py
@@ -31,9 +31,9 @@ if __name__ == "__main__":
         # better to tighten the return limits and set a lower bin count because these envs have rapid
         # swings in Q vals. We don't think it really matters whether you do e.g. rewards x100, returns in [-100, 100] or
         # rewards x1, returns in [-1, 1], but the symlog mapping technically makes these different.
-        "amago.agent.Agent.reward_multiplier": 1.0
-        if args.agent_type == "multitask"
-        else 100.0,  # paper: always 100
+        "amago.agent.Agent.reward_multiplier": (
+            1.0 if args.agent_type == "multitask" else 100.0
+        ),  # paper: always 100
         "amago.nets.actor_critic.NCriticsTwoHot.min_return": -1.0,  # paper: None
         "amago.nets.actor_critic.NCriticsTwoHot.max_return": 1.0,  # paper: None
         "amago.nets.actor_critic.NCriticsTwoHot.output_bins": 32,  # paper: 64

--- a/examples/03_dark_key_to_door.py
+++ b/examples/03_dark_key_to_door.py
@@ -5,6 +5,7 @@ import wandb
 import amago
 from amago.envs.builtin.gym_envs import GymEnv
 from amago.envs.builtin.room_key_door import RoomKeyDoor
+from amago.envs.env_utils import BilevelEpsilonGreedy
 from amago.cli_utils import *
 
 
@@ -69,6 +70,10 @@ if __name__ == "__main__":
             group_name=group_name,
             run_name=run_name,
             val_timesteps_per_epoch=args.meta_horizon * 4,
+            # the fancier exploration schedule mentioned in the appendix can help
+            # when the domain is a true meta-RL problem and the "horizon" time limit
+            # (above) is actually relevant for resetting the task.
+            exploration_wrapper_Cls=BilevelEpsilonGreedy,
         )
         switch_async_mode(experiment, args)
         experiment.start()

--- a/examples/05_kshot_metaworld.py
+++ b/examples/05_kshot_metaworld.py
@@ -4,6 +4,7 @@ import wandb
 
 import amago
 from amago.envs.builtin.metaworld_ml import Metaworld
+from amago.envs.env_utils import BilevelEpsilonGreedy
 from amago.cli_utils import *
 
 
@@ -68,6 +69,7 @@ if __name__ == "__main__":
             val_timesteps_per_epoch=10 * args.k * 500 + 1,
             learning_rate=5e-4,
             grad_clip=2.0,
+            exploration_wrapper_Cls=BilevelEpsilonGreedy,
         )
 
         experiment = switch_async_mode(experiment, args)

--- a/examples/08_tmaze.py
+++ b/examples/08_tmaze.py
@@ -6,7 +6,7 @@ import wandb
 import amago
 from amago.envs.builtin.gym_envs import GymEnv
 from amago.envs.builtin.tmaze import TMazeAltPassive
-from amago.envs.env_utils import ExplorationWrapper
+from amago.envs.env_utils import EpsilonGreedy
 from amago.cli_utils import *
 
 
@@ -16,7 +16,7 @@ def add_cli(parser):
 
 
 @gin.configurable
-class TMazeExploration(ExplorationWrapper):
+class TMazeExploration(EpsilonGreedy):
     """
     The Tmaze environment is meant to evaluate recall over long context lengths without
     testing exploration, but it does this by requiring horizon - 1 deterministic actions
@@ -41,10 +41,8 @@ class TMazeExploration(ExplorationWrapper):
         self.end_window = end_window
         super().__init__(
             env,
-            eps_start_start=eps_start,
-            eps_start_end=eps_start,
-            eps_end_start=eps_end,
-            eps_end_end=eps_end,
+            eps_start=eps_start,
+            eps_end=eps_end,
             steps_anneal=steps_anneal,
         )
 

--- a/examples/11_babyai.py
+++ b/examples/11_babyai.py
@@ -179,9 +179,9 @@ if __name__ == "__main__":
         "amago.nets.actor_critic.NCriticsTwoHot.min_return": -150.0,
         "amago.nets.actor_critic.NCriticsTwoHot.max_return": 150.0,
         "amago.nets.actor_critic.NCriticsTwoHot.output_bins": 32,
-        "amago.agent.Agent.offline_coeff": 1.0
-        if args.agent_type == "multitask"
-        else 0.0,
+        "amago.agent.Agent.offline_coeff": (
+            1.0 if args.agent_type == "multitask" else 0.0
+        ),
         "amago.nets.traj_encoders.TformerTrajEncoder.pos_emb": "fixed",
     }
     switch_traj_encoder(


### PR DESCRIPTION
We don't give exploration much thought because of parallel actors & stochastic policies but this makes it easier to override the exploration details.

Also changes the default from the "bi-level" epsilon-greedy mentioned in the paper to standard epsilon-greedy. The bi-level noise leads to an unintuitive schedule when the "horizon" (max rollout length) is set arbitrarily high and creates a trap for anyone trying a new problem. It'd be really surprising if this meaningfully changed any results other than the full meta-RL envs like dark-key-to-door. Some quick tests show no change. Planning to rewrite the environment wrappers to make the meta-RL setup less involved.

![exploration_schedule](https://github.com/user-attachments/assets/c51a7b7f-2751-4d18-b4c3-ddc70e1c1806)

