### PR TITLE
Custom Metrics Logging

### DIFF
--- a/amago/envs/builtin/babyai.py
+++ b/amago/envs/builtin/babyai.py
@@ -10,7 +10,11 @@ import minigrid
 
 from amago.envs import AMAGOEnv
 from amago.hindsight import GoalSeq
-from amago.envs.env_utils import space_convert, DiscreteActionWrapper
+from amago.envs.env_utils import (
+    space_convert,
+    DiscreteActionWrapper,
+    SpecialMetricHistory,
+)
 
 
 BANNED_BABYAI_TASKS = [
@@ -181,6 +185,9 @@ class MultitaskMetaBabyAI(gym.Env):
         next_obs, reward, terminated, truncated, info = self.env.step(action)
         done = False
         if terminated or truncated:
+            info[
+                f"{SpecialMetricHistory.log_prefix}Episode {self.current_episode} Success"
+            ] = (reward > 0.0)
             self.current_episode += 1
             if self.current_episode > self.k_episodes:
                 done = True

--- a/amago/envs/builtin/babyai.py
+++ b/amago/envs/builtin/babyai.py
@@ -13,7 +13,7 @@ from amago.hindsight import GoalSeq
 from amago.envs.env_utils import (
     space_convert,
     DiscreteActionWrapper,
-    SpecialMetricHistory,
+    AMAGO_ENV_LOG_PREFIX,
 )
 
 
@@ -185,9 +185,9 @@ class MultitaskMetaBabyAI(gym.Env):
         next_obs, reward, terminated, truncated, info = self.env.step(action)
         done = False
         if terminated or truncated:
-            info[
-                f"{SpecialMetricHistory.log_prefix}Episode {self.current_episode} Success"
-            ] = (reward > 0.0)
+            info[f"{AMAGO_ENV_LOG_PREFIX}Episode {self.current_episode} Success"] = (
+                reward > 0.0
+            )
             self.current_episode += 1
             if self.current_episode > self.k_episodes:
                 done = True

--- a/amago/envs/builtin/gym_envs.py
+++ b/amago/envs/builtin/gym_envs.py
@@ -6,7 +6,7 @@ import gymnasium as gym
 import numpy as np
 
 from amago.envs import AMAGOEnv
-from amago.envs.env_utils import SpecialMetricHistory
+from amago.envs.env_utils import AMAGO_ENV_LOG_PREFIX
 from amago.hindsight import GoalSeq
 
 
@@ -190,9 +190,7 @@ class MetaFrozenLake(gym.Env):
         if soft_reset:
             next_state, info = self.soft_reset()
             success = on == "G"
-            info[
-                f"{SpecialMetricHistory.log_prefix}Episode {self.current_k} Success"
-            ] = success
+            info[f"{AMAGO_ENV_LOG_PREFIX}Episode {self.current_k} Success"] = success
             self.current_k += 1
         else:
             next_state, info = self.make_obs(False), {}

--- a/amago/envs/builtin/gym_envs.py
+++ b/amago/envs/builtin/gym_envs.py
@@ -170,8 +170,6 @@ class MetaFrozenLake(gym.Env):
             self.active_map[self.x][self.y] = "H"
 
         on = self.active_map[next_x][next_y]
-
-        episode_end = False
         if on == "G":
             reward = 1.0
             soft_reset = True

--- a/amago/envs/builtin/tmaze.py
+++ b/amago/envs/builtin/tmaze.py
@@ -58,9 +58,9 @@ class TMazeBase(gym.Env):
         )
         self.bias_x, self.bias_y = 1, 2
         self.tmaze_map[self.bias_y, self.bias_x : -self.bias_x] = True  # corridor
-        self.tmaze_map[[self.bias_y - 1, self.bias_y + 1], -self.bias_x - 1] = (
-            True  # goal candidates
-        )
+        self.tmaze_map[
+            [self.bias_y - 1, self.bias_y + 1], -self.bias_x - 1
+        ] = True  # goal candidates
 
         obs_dim = 2 if self.ambiguous_position else 3
         if self.expose_goal:  # test Markov policies

--- a/amago/envs/env_utils.py
+++ b/amago/envs/env_utils.py
@@ -348,6 +348,15 @@ AMAGO_ENV_LOG_PREFIX = SpecialMetricHistory.log_prefix
 
 
 class SequenceWrapper(gym.Wrapper):
+    """
+    A wrapper that handles automatic resets, saving trajectory files to disk,
+    and rollout metrics. Automatically logs total return in all envs.
+    When using the goal-conditioned / relabeling system, this will
+    log meaningful total success rates. We also log any metric from the
+    gym env's `info` dict that begins with "AMAGO_LOG_METRIC"
+    (`amago.envs.env_utils.AMAGO_ENV_LOG_PREFIX`).
+    """
+
     def __init__(
         self,
         env,

--- a/amago/envs/env_utils.py
+++ b/amago/envs/env_utils.py
@@ -344,6 +344,9 @@ class SpecialMetricHistory:
             self.data[env_name][key].append(value)
 
 
+AMAGO_ENV_LOG_PREFIX = SpecialMetricHistory.log_prefix
+
+
 class SequenceWrapper(gym.Wrapper):
     def __init__(
         self,

--- a/amago/envs/env_utils.py
+++ b/amago/envs/env_utils.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from uuid import uuid4
 from dataclasses import dataclass
 from collections import defaultdict
-from typing import Optional, Type, Callable, Iterable
+from typing import Optional, Type, Callable, Iterable, Any
 
 import gymnasium as gym
 import numpy as np
@@ -327,6 +327,23 @@ class ReturnHistory:
 SuccessHistory = ReturnHistory
 
 
+class SpecialMetricHistory:
+    log_prefix = "AMAGO_LOG_METRIC"
+
+    def __init__(self, env_name):
+        self.data = {}
+
+    def add_score(self, env_name: str, key: str, value: Any):
+        if key.startswith(self.log_prefix):
+            key = key[len(self.log_prefix) :].strip()
+        if env_name not in self.data:
+            self.data[env_name] = {}
+        if key not in self.data[env_name]:
+            self.data[env_name][key] = [value]
+        else:
+            self.data[env_name][key].append(value)
+
+
 class SequenceWrapper(gym.Wrapper):
     def __init__(
         self,
@@ -388,6 +405,7 @@ class SequenceWrapper(gym.Wrapper):
         # stores all of the success/return histories
         self.return_history = ReturnHistory(self.env_name)
         self.success_history = SuccessHistory(self.env_name)
+        self.special_history = SpecialMetricHistory(self.env_name)
 
     def reset(self, seed=None) -> Timestep:
         timestep, info = self.env.reset(seed=seed)
@@ -407,6 +425,10 @@ class SequenceWrapper(gym.Wrapper):
         self.total_return += reward
         self.active_traj.add_timestep(timestep)
         self.since_last_save += 1
+        for info_key, info_val in info.items():
+            if info_key.startswith(self.special_history.log_prefix):
+                self.special_history.add_score(self.env.env_name, info_key, info_val)
+
         if timestep.terminal:
             self.return_history.add_score(self.env.env_name, self.total_return)
             success = (
@@ -415,6 +437,7 @@ class SequenceWrapper(gym.Wrapper):
                 else info["success"]
             )
             self.success_history.add_score(self.env.env_name, success)
+
         save = (
             self.save_every is not None and self.since_last_save > self.save_this_time
         )

--- a/amago/learning.py
+++ b/amago/learning.py
@@ -23,6 +23,7 @@ from .agent import Agent
 from amago.envs.env_utils import (
     ReturnHistory,
     SuccessHistory,
+    SpecialMetricHistory,
     ExplorationWrapper,
     EpsilonGreedy,
     SequenceWrapper,
@@ -465,16 +466,24 @@ class Experiment:
 
         return_history = utils.call_async_env(envs, "return_history")
         success_history = utils.call_async_env(envs, "success_history")
+        special_history = utils.call_async_env(envs, "special_history")
         return (
             (obs_seqs, goal_seqs, rl2_seqs),
             hidden_state,
             return_history,
             success_history,
+            special_history,
         )
 
     def collect_new_training_data(self):
         if self.train_timesteps_per_epoch > 0:
-            self.train_buffers, self.hidden_state, returns, successes = self.interact(
+            (
+                self.train_buffers,
+                self.hidden_state,
+                returns,
+                successes,
+                specials,
+            ) = self.interact(
                 self.train_envs,
                 self.train_timesteps_per_epoch,
                 buffers=self.train_buffers,
@@ -482,11 +491,13 @@ class Experiment:
 
     def evaluate_val(self):
         if self.val_timesteps_per_epoch > 0:
-            *_, returns, successes = self.interact(
+            *_, returns, successes, specials = self.interact(
                 self.val_envs,
                 self.val_timesteps_per_epoch,
             )
-            logs_per_process = self.policy_metrics(returns, successes)
+            logs_per_process = self.policy_metrics(
+                returns, successes, specials=specials
+            )
             cur_return = logs_per_process["Average Total Return (Across All Env Names)"]
             if self.verbose:
                 self.accelerator.print(f"Average Return : {cur_return}")
@@ -501,12 +512,12 @@ class Experiment:
         )
         Par = gym.vector.AsyncVectorEnv if self.async_envs else DummyAsyncVectorEnv
         test_envs = Par([make for _ in range(self.parallel_actors)])
-        *_, returns, successes = self.interact(
+        *_, returns, successes, specials = self.interact(
             test_envs,
             timesteps,
             render=render,
         )
-        logs = self.policy_metrics(returns, successes)
+        logs = self.policy_metrics(returns, successes, specials)
         self.log(logs, key="test")
         test_envs.close()
         return logs
@@ -546,10 +557,16 @@ class Experiment:
         """
         return {}
 
-    def policy_metrics(self, returns: ReturnHistory, successes: SuccessHistory):
+    def policy_metrics(
+        self,
+        returns: ReturnHistory,
+        successes: SuccessHistory,
+        specials: SpecialMetricHistory,
+    ) -> dict:
         return_by_env_name = {}
         success_by_env_name = {}
-        for ret, suc in zip(returns, successes):
+        specials_by_env_name = {}
+        for ret, suc, spe in zip(returns, successes, specials):
             for env_name, scores in ret.data.items():
                 if env_name in return_by_env_name:
                     return_by_env_name[env_name] += scores
@@ -560,7 +577,14 @@ class Experiment:
                     success_by_env_name[env_name] += scores
                 else:
                     success_by_env_name[env_name] = scores
-
+            for env_name, specials_dict in spe.data.items():
+                for special_key, special_val in specials_dict.items():
+                    if env_name not in specials_by_env_name:
+                        specials_by_env_name[env_name] = {}
+                    if special_key not in specials_by_env_name[env_name]:
+                        specials_by_env_name[env_name][special_key] = special_val
+                    else:
+                        specials_by_env_name[env_name][special_key] += special_val
         avg_ret_per_env = {
             f"Average Total Return in {name}": np.array(scores).mean()
             for name, scores in return_by_env_name.items()
@@ -569,12 +593,19 @@ class Experiment:
             f"Average Success Rate in {name}": np.array(scores).mean()
             for name, scores in success_by_env_name.items()
         }
+        avg_special_per_env = {
+            f"Average {special_key} in {name}": np.array(special_vals).mean()
+            for name, specials_dict in specials_by_env_name.items()
+            for special_key, special_vals in specials_dict.items()
+        }
         avg_return_overall = {
             "Average Total Return (Across All Env Names)": np.array(
                 list(avg_ret_per_env.values())
             ).mean()
         }
-        return avg_ret_per_env | avg_suc_per_env | avg_return_overall
+        return (
+            avg_ret_per_env | avg_suc_per_env | avg_return_overall | avg_special_per_env
+        )
 
     def compute_loss(self, batch: Batch, log_step: bool):
         critic_loss, actor_loss = self.policy_aclr(batch, log_step=log_step)

--- a/amago/learning.py
+++ b/amago/learning.py
@@ -563,31 +563,22 @@ class Experiment:
         successes: SuccessHistory,
         specials: SpecialMetricHistory,
     ) -> dict:
-        return_by_env_name = {}
-        success_by_env_name = {}
-        specials_by_env_name = {}
+        returns_by_env_name = defaultdict(list)
+        success_by_env_name = defaultdict(list)
+        specials_by_env_name = defaultdict(lambda: defaultdict(list))
+
         for ret, suc, spe in zip(returns, successes, specials):
             for env_name, scores in ret.data.items():
-                if env_name in return_by_env_name:
-                    return_by_env_name[env_name] += scores
-                else:
-                    return_by_env_name[env_name] = scores
+                returns_by_env_name[env_name].extend(scores)
             for env_name, scores in suc.data.items():
-                if env_name in success_by_env_name:
-                    success_by_env_name[env_name] += scores
-                else:
-                    success_by_env_name[env_name] = scores
+                success_by_env_name[env_name].extend(scores)
             for env_name, specials_dict in spe.data.items():
                 for special_key, special_val in specials_dict.items():
-                    if env_name not in specials_by_env_name:
-                        specials_by_env_name[env_name] = {}
-                    if special_key not in specials_by_env_name[env_name]:
-                        specials_by_env_name[env_name][special_key] = special_val
-                    else:
-                        specials_by_env_name[env_name][special_key] += special_val
+                    specials_by_env_name[env_name][special_key].extend(special_val)
+
         avg_ret_per_env = {
             f"Average Total Return in {name}": np.array(scores).mean()
-            for name, scores in return_by_env_name.items()
+            for name, scores in returns_by_env_name.items()
         }
         avg_suc_per_env = {
             f"Average Success Rate in {name}": np.array(scores).mean()


### PR DESCRIPTION
We are slowly abandoning any attempt to automate k-shot resets at the wrapper level and prefer to set that up inside the environment itself. We now accumulate per-environment metrics for any key in the env's `info` dict that begins with "AMAGO_LOG_METRIC". Can be used to log meta-learning stats like the success rate per episode.