### PR TITLE
`jax` env device placement & `accelerate`

### DIFF
--- a/amago/envs/builtin/xland_minigrid.py
+++ b/amago/envs/builtin/xland_minigrid.py
@@ -1,5 +1,6 @@
 import random
 from collections import defaultdict
+import tqdm
 from typing import Optional
 
 import gymnasium as gym
@@ -13,7 +14,6 @@ except ImportError:
     xminigrid = None
 else:
     import jax.numpy as jnp
-    from jax import device_put as dp
     from xminigrid.wrappers import (
         DirectionObservationWrapper,
         DmEnvAutoResetWrapper,
@@ -52,7 +52,6 @@ class XLandMinigridVectorizedGym(gym.Env):
         train_test_split: str = "train",
         train_test_split_key: int = 0,
         train_test_split_pct: float = 0.8,
-        jax_device: Optional[int] = None,
     ):
         assert (
             jax is not None and xminigrid is not None
@@ -62,12 +61,6 @@ class XLandMinigridVectorizedGym(gym.Env):
         self.k_shots = k_shots
         self.ruleset_benchmark = ruleset_benchmark
         self.parallel_envs = parallel_envs
-        self.jax_device = (
-            jax.devices()[jax_device]
-            if jax_device is not None
-            else jax.devices("cpu")[0]
-        )
-        print(f"Using JAX device {self.jax_device} for XLandMiniGridEnv")
 
         # this always uses cuda memory for some reason?
         benchmark = xminigrid.load_benchmark(name=ruleset_benchmark)
@@ -80,7 +73,6 @@ class XLandMinigridVectorizedGym(gym.Env):
         env, self.env_params = xminigrid.make(
             f"XLand-MiniGrid-R{rooms}-{grid_size}x{grid_size}"
         )
-        self.env_params = dp(self.env_params, self.jax_device)
         self.x_env = RulesAndGoalsObservationWrapper(
             DirectionObservationWrapper(DmEnvAutoResetWrapper(env))
         )
@@ -88,19 +80,11 @@ class XLandMinigridVectorizedGym(gym.Env):
         self._reset_key, self._ruleset_key = jax.random.split(key)
 
         # according to gymnax, jit(vmap()) is faster than vmap(jit())... seems to be true here
-        self.x_sample = jax.jit(
-            jax.vmap(self.benchmark.sample_ruleset, in_axes=(0,)),
-            device=self.jax_device,
-        )
-        self.x_reset = jax.jit(
-            jax.vmap(self.x_env.reset, in_axes=(0, 0)), device=self.jax_device
-        )
-        self.x_step = jax.jit(
-            jax.vmap(self.x_env.step, in_axes=(0, 0, 0)), device=self.jax_device
-        )
-        self.x_swap_rules = jax.jit(_swap_rules, device=self.jax_device)
-        self.x_swap_tsteps = jax.jit(_swap_trees, device=self.jax_device)
-        self.x_swap_tsteps_new = jax.jit(_swap_trees, device=self.jax_device)
+        self.x_sample = jax.jit(jax.vmap(self.benchmark.sample_ruleset, in_axes=(0,)))
+        self.x_reset = jax.jit(jax.vmap(self.x_env.reset, in_axes=(0, 0)))
+        self.x_step = jax.jit(jax.vmap(self.x_env.step, in_axes=(0, 0, 0)))
+        self.x_swap_rules = jax.jit(_swap_rules)
+        self.x_swap_tsteps = jax.jit(_swap_trees)
 
         obs_shapes = self.x_env.observation_shape(self.env_params)
         self.max_steps_per_episode = self.env_params.max_steps
@@ -122,29 +106,17 @@ class XLandMinigridVectorizedGym(gym.Env):
         ruleset = self.x_sample(self.new_ruleset_keys())
         self.env_params = self.env_params.replace(ruleset=ruleset)
         self.x_timestep = self.x_reset(self.env_params, self.new_reset_keys())
-        self.current_episode = jnp.zeros(
-            self.parallel_envs, dtype=jnp.int32, device=self.jax_device
-        )
-        self.episode_return = jnp.zeros(
-            self.parallel_envs, dtype=jnp.float32, device=self.jax_device
-        )
-        self.episode_steps = jnp.zeros(
-            self.parallel_envs, dtype=jnp.int32, device=self.jax_device
-        )
+        self.current_episode = jnp.zeros(self.parallel_envs, dtype=jnp.int32)
+        self.episode_return = jnp.zeros(self.parallel_envs, dtype=jnp.float32)
+        self.episode_steps = jnp.zeros(self.parallel_envs, dtype=jnp.int32)
 
     def new_reset_keys(self):
-        keys = dp(
-            jax.random.split(self._reset_key, num=self.parallel_envs + 1),
-            self.jax_device,
-        )
+        keys = jax.random.split(self._reset_key, num=self.parallel_envs + 1)
         self._reset_key = keys[0]
         return keys[1:]
 
     def new_ruleset_keys(self):
-        keys = dp(
-            jax.random.split(self._ruleset_key, num=self.parallel_envs + 1),
-            self.jax_device,
-        )
+        keys = jax.random.split(self._ruleset_key, num=self.parallel_envs + 1)
         self._ruleset_key = keys[0]
         return keys[1:]
 
@@ -158,9 +130,6 @@ class XLandMinigridVectorizedGym(gym.Env):
         direction_done = np.concatenate(
             (obs["direction"], done[:, np.newaxis]), axis=-1
         )
-        # it seems more in the spirit of AdA's XLand to give the "goal" as an observation
-        # but let the agent meta-learn the "rules"... though it's not clear if that
-        # makes xland minigrid easier than it was meant to be...
         return {
             "grid": np.array(obs["img"], dtype=np.uint8),
             "direction_done": direction_done,
@@ -169,7 +138,7 @@ class XLandMinigridVectorizedGym(gym.Env):
 
     def reset(self, *args, **kwargs):
         # set all done, then reset if done
-        is_done = jnp.ones(self.parallel_envs, dtype=jnp.bool_, device=self.jax_device)
+        is_done = jnp.ones(self.parallel_envs, dtype=jnp.bool_)
         return self.reset_if_done(is_done)
 
     def reset_if_done(self, is_done):
@@ -209,7 +178,7 @@ class XLandMinigridVectorizedGym(gym.Env):
         return self.get_obs(), {}
 
     def step(self, action):
-        action = jnp.array(action, device=self.jax_device)
+        action = jnp.array(action)
         assert action.shape == (self.parallel_envs,)
 
         self.episode_steps += 1
@@ -258,41 +227,41 @@ if __name__ == "__main__":
     import matplotlib.pyplot as plt
     from amago.envs import AMAGOEnv, SequenceWrapper
 
-    env = XLandMinigridVectorizedGym(
-        parallel_envs=4,
-        rooms=1,
-        grid_size=9,
-        ruleset_benchmark="trivial-1m",
-        train_test_split="train",
-        train_test_split_key=0,
-        k_shots=2,
-        jax_device=6,
-    )
-    env = AMAGOEnv(env, env_name="XLandMiniGridEnv", batched_envs=4)
-    env = SequenceWrapper(env)
+    with jax.default_device(jax.devices("gpu")[0]):
+        env = XLandMinigridVectorizedGym(
+            parallel_envs=4,
+            rooms=1,
+            grid_size=9,
+            ruleset_benchmark="trivial-1m",
+            train_test_split="train",
+            train_test_split_key=0,
+            k_shots=2,
+        )
+        env = AMAGOEnv(env, env_name="XLandMiniGridEnv", batched_envs=4)
+        env = SequenceWrapper(env)
 
-    render_idxs = None
-
-    if render_idxs is not None:
-        fig, axs = plt.subplots(1, len(render_idxs))
-
-    env.reset()
-    steps = 3_000
-    start = time.time()
-    for step in tqdm.tqdm(range(steps)):
-        print(env.current_episode)
-        action = np.array(
-            [env.action_space.sample() for _ in range(env.parallel_envs)]
-        )[:, np.newaxis]
-        next_state, reward, terminated, truncated, info = env.step(action)
+        render_idxs = None
 
         if render_idxs is not None:
-            for _i, ax in zip(render_idxs, axs):
-                ax.clear()
-                img = env.unwrapped.render(env_idx=_i)
-                ax.imshow(img)
-            plt.pause(0.01)
-            fig.canvas.draw()
+            fig, axs = plt.subplots(1, len(render_idxs))
 
-    end = time.time()
-    print(f"FPS: {steps / (end - start)}")
+        env.reset()
+        steps = 3_000
+        start = time.time()
+        for step in tqdm.tqdm(range(steps)):
+            print(env.current_episode)
+            action = np.array(
+                [env.action_space.sample() for _ in range(env.parallel_envs)]
+            )[:, np.newaxis]
+            next_state, reward, terminated, truncated, info = env.step(action)
+
+            if render_idxs is not None:
+                for _i, ax in zip(render_idxs, axs):
+                    ax.clear()
+                    img = env.unwrapped.render(env_idx=_i)
+                    ax.imshow(img)
+                plt.pause(0.01)
+                fig.canvas.draw()
+
+        end = time.time()
+        print(f"FPS: {steps / (end - start)}")

--- a/amago/learning.py
+++ b/amago/learning.py
@@ -91,7 +91,7 @@ class Experiment:
     l2_coeff: float = 1e-3
     mixed_precision: str = "no"
 
-    def start(self):
+    def __post_init__(self):
         self.accelerator = Accelerator(
             gradient_accumulation_steps=self.batches_per_update,
             device_placement=True,
@@ -101,6 +101,8 @@ class Experiment:
             ],
             mixed_precision=self.mixed_precision,
         )
+
+    def start(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             warnings.filterwarnings("always", category=utils.AmagoWarning)

--- a/examples/02_gymnax.py
+++ b/examples/02_gymnax.py
@@ -7,7 +7,7 @@ from functools import partial
 
 import gymnax
 from gymnax.wrappers import GymnaxToVectorGymWrapper
-
+import torch
 import jax
 import jax.numpy as jnp
 import wandb
@@ -22,7 +22,6 @@ def add_cli(parser):
     parser.add_argument("--env", type=str, required=True)
     parser.add_argument("--max_seq_len", type=int, default=128)
     parser.add_argument("--eval_timesteps", type=int, default=1000)
-    parser.add_argument("--jax_device_idx", type=int, default=None)
     return parser
 
 
@@ -122,42 +121,35 @@ if __name__ == "__main__":
         memory_size=args.memory_size,
         layers=args.memory_layers,
     )
-
-    test_env, _params = gymnax.make(args.env)
-    test_obs_shape = test_env.observation_space(_params).shape
+    with jax.default_device(jax.devices("cpu")[0]):
+        test_env, env_params = gymnax.make(args.env)
+        test_obs_shape = test_env.observation_space(env_params).shape
     simple_switch_tstep_encoder(config, test_obs_shape)
 
     use_config(config, args.configs)
-
-    # free speedup by doing env computation on a spare GPU
-    # e.g. `CUDA_VISIBLE_DEVICES=1,2 python ... --jax_device_idx 1` will put AMAGO training on gpu id 1, gymnax on gpu id 2
-    jax_device = (
-        jax.devices("cpu")[0]
-        if args.jax_device_idx is None
-        else jax.devices()[args.jax_device_idx]
+    make_env = partial(
+        make_gymnax_amago, env_name=args.env, parallel_envs=args.parallel_actors
     )
-
-    with jax.default_device(jax_device):
-        make_env = partial(
-            make_gymnax_amago, env_name=args.env, parallel_envs=args.parallel_actors
+    group_name = f"{args.run_name}_{args.env}"
+    for trial in range(args.trials):
+        run_name = group_name + f"_trial_{trial}"
+        experiment = create_experiment_from_cli(
+            args,
+            make_train_env=make_env,
+            make_val_env=make_env,
+            max_seq_len=args.max_seq_len,
+            traj_save_len=args.max_seq_len * 20,
+            run_name=run_name,
+            group_name=group_name,
+            val_timesteps_per_epoch=args.eval_timesteps,
+            grad_clip=2.0,
+            l2_coeff=1e-4,
+            save_trajs_as="npz-compressed",
         )
-        group_name = f"{args.run_name}_{args.env}"
-        for trial in range(args.trials):
-            run_name = group_name + f"_trial_{trial}"
-            experiment = create_experiment_from_cli(
-                args,
-                make_train_env=make_env,
-                make_val_env=make_env,
-                max_seq_len=args.max_seq_len,
-                traj_save_len=args.max_seq_len * 20,
-                run_name=run_name,
-                group_name=group_name,
-                val_timesteps_per_epoch=args.eval_timesteps,
-                grad_clip=2.0,
-                l2_coeff=1e-4,
-                save_trajs_as="npz-compressed",
-            )
-            experiment = switch_async_mode(experiment, args)
+        experiment = switch_async_mode(experiment, args)
+        amago_device = experiment.DEVICE.index or torch.cuda.current_device()
+        env_device = jax.devices("gpu")[amago_device]
+        with jax.default_device(env_device):
             experiment.start()
             if args.ckpt is not None:
                 experiment.load_checkpoint(args.ckpt)

--- a/examples/02_gymnax.py
+++ b/examples/02_gymnax.py
@@ -1,4 +1,7 @@
 from argparse import ArgumentParser
+import os
+
+os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
 import math
 from functools import partial
 


### PR DESCRIPTION
1. init accelerator on `Experiment` init, so that the device is available before `start`
2. Stop trying to set the device of jax envs within the gym wrapper
3. Use `Experiment` device to set jax to the same default device. accelerate then handles jax device assignment indirectly
4. Cancel jax [default](https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html) of stealing 75% of gpu memory from pytorch in examples, since we're only using it for the envs.

2-gpu accelerate gymnax examples with l=128 5M transformers > 100k total fps