### PR TITLE
Flex Attention

### DIFF
--- a/amago/agent.py
+++ b/amago/agent.py
@@ -43,8 +43,8 @@ class Agent(nn.Module):
         rl2_space: gym.spaces.Box,
         action_space: gym.spaces.Space,
         max_seq_len: int,
-        tstep_encoder_Cls: Type[TstepEncoder] = FFTstepEncoder,
-        traj_encoder_Cls: Type[TrajEncoder] = TformerTrajEncoder,
+        tstep_encoder_type: Type[TstepEncoder] = FFTstepEncoder,
+        traj_encoder_type: Type[TrajEncoder] = TformerTrajEncoder,
         num_critics: int = 4,
         num_critics_td: int = 2,
         online_coeff: float = 1.0,
@@ -86,11 +86,11 @@ class Agent(nn.Module):
         self.use_target_actor = use_target_actor
         self.max_seq_len = max_seq_len
 
-        self.tstep_encoder = tstep_encoder_Cls(
+        self.tstep_encoder = tstep_encoder_type(
             obs_space=obs_space,
             rl2_space=rl2_space,
         )
-        self.traj_encoder = traj_encoder_Cls(
+        self.traj_encoder = traj_encoder_type(
             tstep_dim=self.tstep_encoder.emb_dim,
             max_seq_len=max_seq_len,
         )

--- a/amago/cli_utils.py
+++ b/amago/cli_utils.py
@@ -159,13 +159,13 @@ def switch_tstep_encoder(config: dict, arch: str, **kwargs):
     """
     assert arch in ["ff", "cnn"]
     if arch == "ff":
-        config["amago.agent.Agent.tstep_encoder_Cls"] = (
+        config["amago.agent.Agent.tstep_encoder_type"] = (
             amago.nets.tstep_encoders.FFTstepEncoder
         )
         ff_config = "amago.nets.tstep_encoders.FFTstepEncoder"
         config.update({f"{ff_config}.{key}": val for key, val in kwargs.items()})
     elif arch == "cnn":
-        config["amago.agent.Agent.tstep_encoder_Cls"] = (
+        config["amago.agent.Agent.tstep_encoder_type"] = (
             amago.nets.tstep_encoders.CNNTstepEncoder
         )
         cnn_config = "amago.nets.tstep_encoders.CNNTstepEncoder"
@@ -182,7 +182,7 @@ def switch_traj_encoder(config: dict, arch: str, memory_size: int, layers: int):
         tformer_config = "amago.nets.traj_encoders.TformerTrajEncoder"
         config.update(
             {
-                "amago.agent.Agent.traj_encoder_Cls": amago.nets.traj_encoders.TformerTrajEncoder,
+                "amago.agent.Agent.traj_encoder_type": amago.nets.traj_encoders.TformerTrajEncoder,
                 f"{tformer_config}.d_model": memory_size,
                 f"{tformer_config}.d_ff": memory_size * 4,
                 f"{tformer_config}.n_layers": layers,
@@ -192,7 +192,7 @@ def switch_traj_encoder(config: dict, arch: str, memory_size: int, layers: int):
         gru_config = "amago.nets.traj_encoders.GRUTrajEncoder"
         config.update(
             {
-                "amago.agent.Agent.traj_encoder_Cls": amago.nets.traj_encoders.GRUTrajEncoder,
+                "amago.agent.Agent.traj_encoder_type": amago.nets.traj_encoders.GRUTrajEncoder,
                 f"{gru_config}.n_layers": layers,
                 f"{gru_config}.d_output": memory_size,
                 f"{gru_config}.d_hidden": memory_size,
@@ -203,7 +203,7 @@ def switch_traj_encoder(config: dict, arch: str, memory_size: int, layers: int):
         ff_config = "amago.nets.traj_encoders.FFTrajEncoder"
         config.update(
             {
-                "amago.agent.Agent.traj_encoder_Cls": amago.nets.traj_encoders.FFTrajEncoder,
+                "amago.agent.Agent.traj_encoder_type": amago.nets.traj_encoders.FFTrajEncoder,
                 f"{ff_config}.d_model": memory_size,
                 f"{ff_config}.n_layers": layers,
             }
@@ -212,7 +212,7 @@ def switch_traj_encoder(config: dict, arch: str, memory_size: int, layers: int):
         mamba_config = "amago.nets.traj_encoders.MambaTrajEncoder"
         config.update(
             {
-                "amago.agent.Agent.traj_encoder_Cls": amago.nets.traj_encoders.MambaTrajEncoder,
+                "amago.agent.Agent.traj_encoder_type": amago.nets.traj_encoders.MambaTrajEncoder,
                 f"{mamba_config}.d_model": memory_size,
                 f"{mamba_config}.n_layers": layers,
             }
@@ -283,12 +283,12 @@ def create_experiment_from_cli(
     traj_save_len: int,
     group_name: str,
     run_name: str,
-    experiment_Cls=amago.Experiment,
+    experiment_type=amago.Experiment,
     **extra_experiment_kwargs,
 ):
     cli = command_line_args
 
-    experiment = experiment_Cls(
+    experiment = experiment_type(
         agent_type=(
             amago.agent.Agent
             if cli.agent_type == "agent"

--- a/amago/cli_utils.py
+++ b/amago/cli_utils.py
@@ -220,42 +220,6 @@ def switch_traj_encoder(config: dict, arch: str, memory_size: int, layers: int):
     return config
 
 
-def naive(config: dict, turn_off_fbc: bool = False):
-    config.update(
-        {
-            "amago.nets.traj_encoders.TformerTrajEncoder.activation": "gelu",
-            "amago.nets.actor_critic.NCritics.activation": "relu",
-            "amago.nets.actor_critic.Actor.activation": "relu",
-            "amago.nets.tstep_encoders.FFTstepEncoder.activation": "relu",
-            "amago.nets.tstep_encoders.CNNTstepEncoder.activation": "relu",
-            "amago.nets.transformer.TransformerLayer.normformer_norms": False,
-            "amago.nets.transformer.TransformerLayer.sigma_reparam": False,
-            "amago.nets.transformer.AttentionLayer.sigma_reparam": False,
-            "amago.nets.transformer.AttentionLayer.head_scaling": False,
-            "amago.agent.Agent.num_critics": 2,
-            "amago.agent.Agent.gamma": 0.99,
-            "amago.agent.Agent.use_multigamma": False,
-        }
-    )
-
-    if turn_off_fbc:
-        config.update({"amago.agent.Agent.offline_coeff": 0.0})
-
-    return config
-
-
-def adaptive(config: dict):
-    config.update(
-        {
-            "amago.nets.traj_encoders.TformerTrajEncoder.activation": "adaptive",
-            "amago.nets.actor_critic.NCritics.activation": "adaptive",
-            "amago.nets.actor_critic.Actor.activation": "adaptive",
-            "amago.nets.tstep_encoders.FFTstepEncoder.activation": "adaptive",
-            "amago.nets.tstep_encoders.CNNTstepEncoder.activation": "adaptive",
-        }
-    )
-
-
 def use_config(
     custom_params: dict, gin_configs: list[str] | None = None, finalize: bool = True
 ):

--- a/amago/envs/amago_env.py
+++ b/amago/envs/amago_env.py
@@ -348,7 +348,7 @@ class SequenceWrapper(gym.Wrapper):
 @dataclass
 class EnvCreator:
     make_env: Callable
-    exploration_wrapper_Cls: Type[ExplorationWrapper]
+    exploration_wrapper_type: Type[ExplorationWrapper]
     make_dset: bool
     dset_root: str
     dset_name: str
@@ -373,8 +373,8 @@ class EnvCreator:
     def __call__(self):
         env = self.make_env()
         self.already_vectorized = env.batched_envs > 1
-        if self.exploration_wrapper_Cls is not None:
-            env = self.exploration_wrapper_Cls(env)
+        if self.exploration_wrapper_type is not None:
+            env = self.exploration_wrapper_type(env)
         env = SequenceWrapper(
             env,
             save_every=(self.save_every_low, self.save_every_high),

--- a/amago/learning.py
+++ b/amago/learning.py
@@ -46,7 +46,7 @@ class Experiment:
     make_val_env: callable | Iterable[callable]
     parallel_actors: int = 10
     env_mode: str = "async"
-    exploration_wrapper_Cls: Optional[type[ExplorationWrapper]] = EpsilonGreedy
+    exploration_wrapper_type: Optional[type[ExplorationWrapper]] = EpsilonGreedy
     sample_actions: bool = True
     force_reset_train_envs_every: Optional[int] = None
 
@@ -62,7 +62,7 @@ class Experiment:
     dset_name: str = None
     dset_max_size: int = 15_000
     dset_filter_pct: Optional[float] = 0.1
-    relabel_Cls: type[Relabeler] = Relabeler
+    relabel_type: type[Relabeler] = Relabeler
     goal_importance_sampling: bool = False
     stagger_traj_file_lengths: bool = True
     save_trajs_as: str = "npz"
@@ -174,11 +174,11 @@ class Experiment:
         else:
             raise ValueError(f"Invalid `env_mode` {self.env_mode}")
 
-        if self.exploration_wrapper_Cls is not None and not issubclass(
-            self.exploration_wrapper_Cls, ExplorationWrapper
+        if self.exploration_wrapper_type is not None and not issubclass(
+            self.exploration_wrapper_type, ExplorationWrapper
         ):
             utils.amago_warning(
-                f"Implement exploration strategies by subclassing `ExplorationWrapper` and setting the `Experiment.exploration_wrapper_Cls`"
+                f"Implement exploration strategies by subclassing `ExplorationWrapper` and setting the `Experiment.exploration_wrapper_type`"
             )
 
         # wrap environments to save trajectories to replay buffer
@@ -197,7 +197,7 @@ class Experiment:
                 make_dset=True,
                 dset_split="train",
                 # adds exploration noise
-                exploration_wrapper_Cls=self.exploration_wrapper_Cls,
+                exploration_wrapper_type=self.exploration_wrapper_type,
                 **shared_env_kwargs,
             )
             for env_func in make_train_envs
@@ -209,7 +209,7 @@ class Experiment:
                 make_dset=False,
                 dset_split="val",
                 # no exploration noise
-                exploration_wrapper_Cls=None,
+                exploration_wrapper_type=None,
                 **shared_env_kwargs,
             )
             for env_func in make_val_envs
@@ -300,7 +300,7 @@ class Experiment:
 
     def init_dsets(self):
         self.train_dset = TrajDset(
-            relabeler=self.relabel_Cls(),
+            relabeler=self.relabel_type(),
             dset_root=self.dset_root,
             dset_name=self.dset_name,
             dset_split="train",

--- a/amago/nets/traj_encoders.py
+++ b/amago/nets/traj_encoders.py
@@ -125,6 +125,9 @@ class TformerTrajEncoder(TrajEncoder):
         activation: str = "leaky_relu",
         norm: str = "layer",
         causal: bool = True,
+        sigma_reparam: bool = True,
+        normformer_norms: bool = True,
+        head_scaling: bool = True,
         attention_type: type[transformer.SelfAttention] = transformer.FlashAttention,
     ):
         super().__init__(tstep_dim, max_seq_len)
@@ -142,12 +145,16 @@ class TformerTrajEncoder(TrajEncoder):
                     d_qkv=self.head_dim,
                     n_heads=self.n_heads,
                     dropout_qkv=dropout_qkv,
+                    head_scaling=head_scaling,
+                    sigma_reparam=sigma_reparam,
                 ),
                 d_model=self.d_model,
                 d_ff=d_ff,
                 dropout_ff=dropout_ff,
                 activation=activation,
                 norm=norm,
+                sigma_reparam=sigma_reparam,
+                normformer_norms=normformer_norms,
             )
 
         layers = [make_layer() for _ in range(self.n_layers)]

--- a/amago/nets/transformer.py
+++ b/amago/nets/transformer.py
@@ -156,9 +156,9 @@ class CustomAttention(SelfAttention, ABC):
         self._inf_mask = None
 
     @lru_cache
-    def cached_block_mask(self, q_len: int, kv_len: int):
+    def cached_block_mask(self, mask_mod, q_len: int, kv_len: int):
         return create_block_mask(
-            and_masks(self.mask_mod, self.causal_mask),
+            mask_mod,
             B=None,
             H=None,
             Q_LEN=q_len,
@@ -180,10 +180,10 @@ class CustomAttention(SelfAttention, ABC):
         return flex_attention(q, k, v, score_mod, block_mask)
 
     @torch.compile
-    def flex_attention_inf(self, q, k, v, score_mod):
+    def flex_attention_inf(self, q, k, v, score_mod, block_mask):
         # pretend this is a different function than training to keep
         # torch's compilation separate.
-        return flex_attention(q, k, v, score_mod)
+        return flex_attention(q, k, v, score_mod, block_mask)
 
     @torch.compiler.disable
     def forward(self, qkv, key_cache=None, val_cache=None, cache_seqlens=None):
@@ -193,7 +193,9 @@ class CustomAttention(SelfAttention, ABC):
             *_, L, _ = qkv.shape
             q, k, v = torch.unbind(qkv, dim=2)
             # if self._train_mask is None or self._train_mask.shape[-1] < L:
-            self._train_mask = self.cached_block_mask(L, L)
+            self._train_mask = self.cached_block_mask(
+                and_masks(self.mask_mod, self.causal_mask), L, L
+            )
             out = self.flex_attention(
                 q, k, v, score_mod=self.score_mod, block_mask=self._train_mask
             )
@@ -213,13 +215,26 @@ class CustomAttention(SelfAttention, ABC):
                 q_idx = q_idx + cache_seqlens[b]
                 base = self.score_mod(score, b, h, q_idx, kv_idx)
                 counts = kv_idx <= cache_seqlens[b]
-                if self.causal:
-                    counts = counts & (q_idx >= kv_idx)
                 return torch.where(counts, base, -float("inf"))
 
+            def mask_mod_uneven_lenths(b, h, q_idx, kv_idx):
+                q_idx = q_idx + cache_seqlens[b]
+                base = self.mask_mod(b, h, q_idx, kv_idx)
+                if self.causal:
+                    return base & (q_idx >= kv_idx)
+                return base
+
             # if self._inf_mask is None or self._inf_mask.shape[-1] < max_len:
-            # self._inf_mask = self.cached_block_mask(1, max_len)
-            out = self.flex_attention_inf(q, k_cache, v_cache, score_mod_uneven_lengths)
+            inf_mask = create_block_mask(
+                mask_mod_uneven_lenths,
+                B=None,
+                H=None,
+                Q_LEN=1,
+                KV_LEN=max_len,
+            )
+            out = self.flex_attention_inf(
+                q, k_cache, v_cache, score_mod_uneven_lengths, inf_mask
+            )
             return rearrange(out, "b h l e -> b l h e")
 
 

--- a/amago/nets/transformer.py
+++ b/amago/nets/transformer.py
@@ -211,7 +211,6 @@ class SigmaReparamLegacyInit(nn.Module):
         return out
 
 
-@gin.configurable(allowlist=["head_scaling", "sigma_reparam"])
 class AttentionLayer(nn.Module):
     def __init__(
         self,
@@ -254,7 +253,6 @@ class AttentionLayer(nn.Module):
         return out
 
 
-@gin.configurable(denylist=["activation", "norm", "dropout_ff"])
 class TransformerLayer(nn.Module):
     """
     Pre-Norm Self-Attention

--- a/amago/nets/tstep_encoders.py
+++ b/amago/nets/tstep_encoders.py
@@ -87,7 +87,7 @@ class CNNTstepEncoder(TstepEncoder):
         self,
         obs_space,
         rl2_space,
-        cnn_Cls=cnn.NatureishCNN,
+        cnn_type=cnn.NatureishCNN,
         channels_first: bool = False,
         img_features: int = 384,
         rl2_features: int = 12,
@@ -103,7 +103,7 @@ class CNNTstepEncoder(TstepEncoder):
             cnn.DrQv2Aug(4, channels_first=channels_first) if drqv2_aug else lambda x: x
         )
         obs_shape = self.obs_space["observation"].shape
-        self.cnn = cnn_Cls(
+        self.cnn = cnn_type(
             img_shape=obs_shape,
             channels_first=channels_first,
             activation=activation,

--- a/examples/01_basic_gym.py
+++ b/examples/01_basic_gym.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     config = {
         # dictionary that sets default value for kwargs of classes that are marked as `gin.configurable`
         # see https://github.com/google/gin-config for more information. For example:
-        "amago.nets.traj_encoders.TformerTrajEncoder.attention_type": amago.nets.transformer.FlashAttention,  # or "vanilla" if flash attention is not available
+        "amago.nets.traj_encoders.TformerTrajEncoder.attention_type": amago.nets.transformer.VanillaAttention,
     }
     switch_traj_encoder(
         config,

--- a/examples/01_basic_gym.py
+++ b/examples/01_basic_gym.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     config = {
         # dictionary that sets default value for kwargs of classes that are marked as `gin.configurable`
         # see https://github.com/google/gin-config for more information. For example:
-        "amago.nets.traj_encoders.TformerTrajEncoder.attention": "flash",  # or "vanilla" if flash attention is not available
+        "amago.nets.traj_encoders.TformerTrajEncoder.attention_type": amago.nets.transformer.FlashAttention,  # or "vanilla" if flash attention is not available
     }
     switch_traj_encoder(
         config,

--- a/examples/02_gymnax.py
+++ b/examples/02_gymnax.py
@@ -87,7 +87,7 @@ def simple_switch_tstep_encoder(config, obs_shape):
         switch_tstep_encoder(
             config,
             "cnn",
-            cnn_Cls=GridworldCNN,
+            cnn_type=GridworldCNN,
             channels_first=channels_first,
             drqv2_aug=False,
         )

--- a/examples/03_popgym_suite.py
+++ b/examples/03_popgym_suite.py
@@ -14,7 +14,6 @@ def add_cli(parser):
         action="store_true",
         help="Activate 'MultiDomain' POPGym, where agents play 27 POPGym games at the same time in 1-shot format (2 episodes, second one counts).",
     )
-    parser.add_argument("--naive", action="store_true")
     return parser
 
 
@@ -45,8 +44,6 @@ if __name__ == "__main__":
         layers=args.memory_layers,
     )
     switch_tstep_encoder(config, arch="ff", n_layers=2, d_hidden=512, d_output=200)
-    if args.naive:
-        naive(config)
     use_config(config, args.configs)
 
     group_name = f"{args.run_name}_{args.env}"

--- a/examples/04_tmaze.py
+++ b/examples/04_tmaze.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
             run_name=run_name,
             val_timesteps_per_epoch=args.horizon + 1,
             sample_actions=False,  # even softmax prob .999 isn't good enough for this env...
-            exploration_wrapper_Cls=TMazeExploration,
+            exploration_wrapper_type=TMazeExploration,
         )
         switch_async_mode(experiment, args)
         experiment.start()

--- a/examples/05_dark_key_door.py
+++ b/examples/05_dark_key_door.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
             # the fancier exploration schedule mentioned in the appendix can help
             # when the domain is a true meta-RL problem and the "horizon" time limit
             # (above) is actually relevant for resetting the task.
-            exploration_wrapper_Cls=BilevelEpsilonGreedy,
+            exploration_wrapper_type=BilevelEpsilonGreedy,
         )
         switch_async_mode(experiment, args)
         experiment.start()

--- a/examples/07_metaworld.py
+++ b/examples/07_metaworld.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
             val_timesteps_per_epoch=10 * args.k * 500 + 1,
             learning_rate=5e-4,
             grad_clip=2.0,
-            exploration_wrapper_Cls=BilevelEpsilonGreedy,
+            exploration_wrapper_type=BilevelEpsilonGreedy,
         )
 
         experiment = switch_async_mode(experiment, args)

--- a/examples/08_ale.py
+++ b/examples/08_ale.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     elif args.cnn == "impala":
         cnn_type = IMPALAishCNN
 
-    switch_tstep_encoder(config, arch="cnn", cnn_Cls=cnn_type, channels_first=True)
+    switch_tstep_encoder(config, arch="cnn", cnn_type=cnn_type, channels_first=True)
     use_config(config, args.configs)
 
     # Episode lengths in Atari vary widely across games, so we manually set actors

--- a/examples/09_multitask_procgen.py
+++ b/examples/09_multitask_procgen.py
@@ -55,7 +55,9 @@ if __name__ == "__main__":
         layers=args.memory_layers,
     )
 
-    switch_tstep_encoder(config, arch="cnn", cnn_Cls=IMPALAishCNN, channels_first=False)
+    switch_tstep_encoder(
+        config, arch="cnn", cnn_type=IMPALAishCNN, channels_first=False
+    )
     use_config(config, args.configs)
 
     procgen_kwargs = PROCGEN_SETTINGS[args.distribution]

--- a/examples/10_babyai.py
+++ b/examples/10_babyai.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
 
     config = {
         "amago.agent.Agent.reward_multiplier": 1000.0,
-        "amago.agent.Agent.tstep_encoder_Cls": partial(
+        "amago.agent.Agent.tstep_encoder_type": partial(
             BabyTstepEncoder, obs_kind=args.obs_kind
         ),
         "amago.nets.actor_critic.NCriticsTwoHot.min_return": None,

--- a/examples/11_xland_minigrid.py
+++ b/examples/11_xland_minigrid.py
@@ -126,12 +126,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     config = {
-        "amago.agent.Agent.reward_multiplier": 100.0,
-        "amago.agent.Agent.tstep_encoder_Cls": XLandMGTstepEncoder,
+        "amago.agent.Agent.reward_multiplier": 10.0,
+        "amago.agent.Agent.tstep_encoder_type": XLandMGTstepEncoder,
         "amago.envs.exploration.EpsilonGreedy.steps_anneal": 1_000_000,
-        "amago.nets.actor_critic.NCriticsTwoHot.min_return": -25_000,
-        "amago.nets.actor_critic.NCriticsTwoHot.max_return": 25_000,
-        "amago.nets.actor_critic.NCriticsTwoHot.output_bins": 64,
+        "amago.nets.actor_critic.NCriticsTwoHot.min_return": -args.k_shots * 10.0 * 10,
+        "amago.nets.actor_critic.NCriticsTwoHot.max_return": args.k_shots * 10.0 * 10,
+        "amago.nets.actor_critic.NCriticsTwoHot.output_bins": 32,
     }
 
     switch_traj_encoder(


### PR DESCRIPTION
Adds rough/experimental compatibility with [`flex_attention`](https://pytorch.org/blog/flexattention/). Allows for arbitrary sparse attention patterns without needing to implement the inference k/v cache. 

Main benefit is moving the transformer details the first paper mentions (sigma reparam, normformer norms) up to the kwargs of `TransformerTrajEncoder`, and clearing the way to reuse the core `Transformer` in other traj encoders.