### PR TITLE
POPGym Regression (New Update to ICLR Results & MultiDomain Results)

### DIFF
--- a/amago/envs/builtin/metaworld_ml.py
+++ b/amago/envs/builtin/metaworld_ml.py
@@ -89,9 +89,9 @@ class KShotMetaworld(gym.Env):
         soft_reset = False
         if self.current_time >= self.max_episode_length or done:
             soft_reset = True
-            metrics[f"{AMAGO_ENV_LOG_PREFIX} Trial {self.current_trial} Success"] = (
-                self.trial_success
-            )
+            metrics[
+                f"{AMAGO_ENV_LOG_PREFIX} Trial {self.current_trial} Success"
+            ] = self.trial_success
             self.current_time = 0
             self.successes += self.trial_success
             self.trial_success = 0.0

--- a/amago/envs/builtin/popgym_envs.py
+++ b/amago/envs/builtin/popgym_envs.py
@@ -14,7 +14,7 @@ except ImportError:
     )
 
 from amago.envs import AMAGOEnv
-from amago.envs.env_utils import extend_observation_space_by
+from amago.envs.env_utils import extend_box_obs_space_by
 
 
 class _MultiDiscreteToBox(gym.ObservationWrapper):
@@ -62,8 +62,8 @@ class POPGym(gym.Wrapper):
             env = _MultiDiscreteToBox(env)
         self.truncated_is_done = truncated_is_done
         super().__init__(env)
-        self.observation_space = extend_observation_space_by(
-            env.observation_space, 1, low=0.0, high=1.0
+        self.observation_space = extend_box_obs_space_by(
+            env.observation_space, by=1, low=0.0, high=1.0
         )
 
     def reset(self, *args, **kwargs):

--- a/amago/envs/builtin/popgym_envs.py
+++ b/amago/envs/builtin/popgym_envs.py
@@ -14,6 +14,7 @@ except ImportError:
     )
 
 from amago.envs import AMAGOEnv
+from amago.envs.env_utils import extend_observation_space_by
 
 
 class _MultiDiscreteToBox(gym.ObservationWrapper):
@@ -48,8 +49,8 @@ class _DiscreteToBox(gym.ObservationWrapper):
         return arr
 
 
-class POPGymAMAGO(AMAGOEnv):
-    def __init__(self, env_name: str):
+class POPGym(gym.Wrapper):
+    def __init__(self, env_name, truncated_is_done: bool = True):
         str_to_cls = {v["id"]: k for k, v in popgym.envs.ALL.items()}
         env = str_to_cls[env_name]()
         env = Flatten(env)
@@ -59,6 +60,32 @@ class POPGymAMAGO(AMAGOEnv):
             env = _DiscreteToBox(env)
         elif isinstance(env.observation_space, gym.spaces.MultiDiscrete):
             env = _MultiDiscreteToBox(env)
+        self.truncated_is_done = truncated_is_done
+        super().__init__(env)
+        self.observation_space = extend_observation_space_by(
+            env.observation_space, 1, low=0.0, high=1.0
+        )
+
+    def reset(self, *args, **kwargs):
+        obs, info = self.env.reset(*args, **kwargs)
+        self.timer = np.array([0.0])
+        return self.create_obs(obs), info
+
+    def create_obs(self, obs):
+        new_obs = np.concatenate((obs, self.timer), axis=-1)
+        return new_obs
+
+    def step(self, action):
+        self.timer += 1
+        next_obs, reward, terminated, truncated, info = self.env.step(action)
+        if self.truncated_is_done:
+            terminated = terminated or truncated
+        return self.create_obs(next_obs), reward, terminated, truncated, info
+
+
+class POPGymAMAGO(AMAGOEnv):
+    def __init__(self, env_name: str):
+        env = POPGym(env_name)
         super().__init__(env, env_name=env_name)
 
 

--- a/amago/envs/builtin/tmaze.py
+++ b/amago/envs/builtin/tmaze.py
@@ -58,9 +58,9 @@ class TMazeBase(gym.Env):
         )
         self.bias_x, self.bias_y = 1, 2
         self.tmaze_map[self.bias_y, self.bias_x : -self.bias_x] = True  # corridor
-        self.tmaze_map[[self.bias_y - 1, self.bias_y + 1], -self.bias_x - 1] = (
-            True  # goal candidates
-        )
+        self.tmaze_map[
+            [self.bias_y - 1, self.bias_y + 1], -self.bias_x - 1
+        ] = True  # goal candidates
 
         obs_dim = 2 if self.ambiguous_position else 3
         if self.expose_goal:  # test Markov policies

--- a/amago/envs/builtin/xland_minigrid.py
+++ b/amago/envs/builtin/xland_minigrid.py
@@ -29,7 +29,6 @@ def _swap_rules(old_goal, old_rule, old_tile, new_goal, new_rule, new_tile, repl
 
 
 def _swap_trees(old_tree, new_tree, replace):
-
     def select_fn(old, new):
         diff = old.ndim - replace.ndim
         axes = tuple([1 + i for i in range(diff)])

--- a/amago/envs/env_utils.py
+++ b/amago/envs/env_utils.py
@@ -2,9 +2,7 @@ import gymnasium as gym
 import numpy as np
 
 
-def extend_observation_space_by(
-    space: gym.spaces.Box, by: int, low: float, high: float
-):
+def extend_box_obs_space_by(space: gym.spaces.Box, by: int, low: float, high: float):
     assert isinstance(space, gym.spaces.Box)
     return gym.spaces.Box(
         shape=(space.shape[0] + by,),

--- a/amago/envs/env_utils.py
+++ b/amago/envs/env_utils.py
@@ -2,6 +2,17 @@ import gymnasium as gym
 import numpy as np
 
 
+def extend_observation_space_by(
+    space: gym.spaces.Box, by: int, low: float, high: float
+):
+    assert isinstance(space, gym.spaces.Box)
+    return gym.spaces.Box(
+        shape=(space.shape[0] + by,),
+        low=np.concatenate((space.low, (low,) * by), axis=-1),
+        high=np.concatenate((space.high, (high,) * by), axis=-1),
+    )
+
+
 class AlreadyVectorizedEnv(gym.Env):
     """
     Thin wrapper imitating the Async calls of a single environment

--- a/examples/03_popgym_suite.py
+++ b/examples/03_popgym_suite.py
@@ -24,9 +24,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     config = {
-        "amago.nets.actor_critic.NCriticsTwoHot.min_return": -1.0,  # paper: None
-        "amago.nets.actor_critic.NCriticsTwoHot.max_return": 1.0,  # paper: None
-        "amago.nets.actor_critic.NCriticsTwoHot.output_bins": 32,  # paper: 64
+        "amago.nets.actor_critic.NCriticsTwoHot.output_bins": 64,
     }
     traj_encoder_type = switch_traj_encoder(
         config,
@@ -35,8 +33,9 @@ if __name__ == "__main__":
         layers=args.memory_layers,  # paper: 3
     )
     tstep_encoder_type = switch_tstep_encoder(
-        config, arch="ff", n_layers=2, d_hidden=512, d_output=200
+        config, arch="ff", n_layers=2, d_hidden=256, d_output=256
     )
+    exploration_type = switch_exploration(config, "egreedy", steps_anneal=400_000)
     agent_type = switch_agent(config, args.agent_type, reward_multiplier=100.0)
     use_config(config, args.configs)
 
@@ -57,8 +56,11 @@ if __name__ == "__main__":
             run_name=run_name,
             tstep_encoder_type=tstep_encoder_type,
             traj_encoder_type=traj_encoder_type,
+            exploration_wrapper_type=exploration_type,
             agent_type=agent_type,
             val_timesteps_per_epoch=2000,
+            learning_rate=3e-4,
+            grad_clip=2.0,
         )
         experiment = switch_async_mode(experiment, args.mode)
         experiment.start()


### PR DESCRIPTION
A technical note on POPGym:

Our original env stack automatically created a simple timer feature alongside previous actions/rewards. This info is redundant to Transformer position idxs, but we were using it to correct for treating `done = terminated or truncated` (no infinite bootstrapping). As of a recent update the auto timer is gone (to avoid setting a finite horizon for every env), and `done = terminated` (infinite bootstrapping). 

I test easy popgym tasks like AutoEncodeEasy/Medium, RepeatPreviousEasy/Med/Hard, RepeatFirstEasy/Med/Hard often, but had not tested tasks that stress sample efficiency with the 15M timestep limit (CountRecallHard, BattleshipEasy, MineSweeperEasy, MultiarmedBanditHard, ConcentrationEasy). It turns out many of these use `truncated` signals and we need `done = truncated` to match our own results. It seems to make a huge difference to treat these as finite horizon POMDPs.

Quick fix restores the timer and truncation with a POPGym wrapper. Reference curves for the hard tasks listed above will be posted soon.

Also includes a few hparam changes made while replicating the multi-task POPGym from the recent paper. That log also coming soon (last few days of training). 




