### PR TITLE
Note on VanillaAttention Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ conda activate amago
 pip install -e amago
 ```
 
-There are some optional installs for additional features:
+- `pip install -e amago[flash]`: The base Transformer policy uses [FlashAttention 2.0](https://github.com/Dao-AILab/flash-attention) by default. We recommend installing `flash_attn` if your GPU is compatible. Please refer to the [official installation instructions](https://github.com/Dao-AILab/flash-attention) if you run into issues.
 
-- `pip install -e amago[flash]`: The default Transformer policy has an option for [FlashAttention 2.0](https://github.com/Dao-AILab/flash-attention). FlashAttention leads to significant speedups on long sequences if your GPU is compatible. Please refer to the [official installation instructions](https://github.com/Dao-AILab/flash-attention) if you run into issues.
+There are some optional installs for additional features:
 
 - `pip install -e amago[mamba]`: Enables [Mamba](https://arxiv.org/abs/2312.00752) sequence model policies. 
 

--- a/amago/envs/builtin/ale_retro.py
+++ b/amago/envs/builtin/ale_retro.py
@@ -138,6 +138,7 @@ class AtariGame(gym.Env):
         terminal_on_life_loss: bool = False,
         version: str = "v5",
         continuous_action_threshold: float = 0.5,
+        clip_rewards: bool = False,
     ):
         super().__init__()
         self.resolution = resolution
@@ -146,6 +147,7 @@ class AtariGame(gym.Env):
         self.terminal_on_life_loss = terminal_on_life_loss
         self.grayscale = grayscale
         self.channels_last = channels_last
+        self.clip_rewards = clip_rewards
         self.rom_name = game
 
         # create environment
@@ -217,6 +219,8 @@ class AtariGame(gym.Env):
         truncated = truncated or self._time >= self.time_limit
         if self.terminal_on_life_loss:
             terminated = terminated or info["lives"] < self.lives
+        if self.clip_rewards:
+            reward = max(min(reward, 1.0), -1.0)
         return self.screen(next_obs), reward, terminated, truncated, info
 
 

--- a/examples/03_popgym_suite.py
+++ b/examples/03_popgym_suite.py
@@ -3,7 +3,6 @@ from argparse import ArgumentParser
 import wandb
 
 from amago.envs.builtin.popgym_envs import POPGymAMAGO, MultiDomainPOPGymAMAGO
-from amago.agent import binary_filter
 from amago.cli_utils import *
 
 
@@ -36,6 +35,7 @@ if __name__ == "__main__":
         # learnable position embedding
         "amago.nets.transformer.LearnablePosEmb.max_time_idx": artificial_horizon,
         "amago.nets.traj_encoders.TformerTrajEncoder.pos_emb": "learnable",
+        "amago.nets.traj_encoders.TformerTrajEncoder.attention_type": amago.nets.transformer.FlashAttention,
         "amago.nets.policy_dists.Discrete.clip_prob_high": 1.0, # not important
         "amago.nets.policy_dists.Discrete.clip_prob_low": 1e-6, # not important
         # paper version defaulted to large set of gamma values

--- a/examples/08_ale.py
+++ b/examples/08_ale.py
@@ -2,7 +2,6 @@ from argparse import ArgumentParser
 from functools import partial
 
 import wandb
-import gym
 
 from amago.envs.builtin.ale_retro import AtariAMAGOWrapper, AtariGame
 from amago.nets.cnn import NatureishCNN, IMPALAishCNN
@@ -36,7 +35,16 @@ ATARI_TIME_LIMIT = (30 * 60 * 60) // 5  # (30 minutes of game time)
 
 def make_atari_game(game_name):
     return AtariAMAGOWrapper(
-        AtariGame(game=game_name, use_discrete_actions=True),
+        AtariGame(
+            game=game_name,
+            action_space="discrete",
+            terminal_on_life_loss=False,
+            version="v5",
+            frame_skip=5,
+            grayscale=False,
+            sticky_action_prob=0.25,
+            clip_rewards=False,
+        ),
     )
 
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -203,7 +203,7 @@ The `TrajEncoder` is a seq2seq model that enables long-term memory and in-contex
 
 3. `MambaTrajEncoder`: [Mamba](https://arxiv.org/abs/2312.00752) is a state-space model with similar conceptual strengths and weaknesses as an RNN. However, it runs significantly faster during training.
 
-4. `TformerTrajEncoder`: a Transformer model with a number of tricks for stability in RL. Transformers are great at RL memory problems because they don't "forget" anything and only need to learn to *retrieve* info at timesteps where it is immediately useful. There are several choices of self-attention mechanism. We recommend [flash_attn](https://github.com/Dao-AILab/flash-attention) if it will run on your GPU. If not, we'll fall back to a slower pytorch version. There is experimental support for [`flex_attention`](https://pytorch.org/blog/flexattention/) (pytorch >= 2.5). See the "Customize Anything Else" section for how to switch defaults.
+4. `TformerTrajEncoder`: a Transformer model with a number of tricks for stability in RL. Transformers are great at RL memory problems because they don't "forget" anything and only need to learn to *retrieve* info at timesteps where it is immediately useful. There are several choices of self-attention mechanism. We recommend [flash_attn](https://github.com/Dao-AILab/flash-attention) if it will run on your GPU. There is experimental support for [`flex_attention`](https://pytorch.org/blog/flexattention/) (pytorch >= 2.5). See the "Customize Anything Else" section for how to switch defaults.
 
 We can select a `TrajEncoder` just like a `TstepEncoder`:
 


### PR DESCRIPTION
Wraps up the fix started in #80, patching a bug where the VanillaAttention and FlexAttention k/v cache fills its values incorrectly when the batched envs are on different time idxs.


a tragic github tale:

- regular non-flash attention has always been in the repo but didn't have cached inference and was just meant for debugging
- during a marathon update (#51) to the repo i remove support for models that don't cache in a hidden state
- instead of removing VanillaAttention, I decide to add a k/v cache that mimics the flash attention version (#56)
- passes memory checks in POPGym & TMaze, outputs values close to flash
-  i decide it might be convenient to default to FlashAttention and auto fall back to Vanilla if it's not installed.
- same method gets used later for FlexAttention (#60)
- k/v indexing is silently broken when each actor is on a different timestep of the env. doesn't show up in results because i happen to be testing on envs that reset at consistent sequence lengths.
- MineSweeperMedium resets based on agent failure (#79) and breaks VanillaAttention
- I spend a long night trying to figure it out and rush out #80. 
- Have now checked TMaze, easy POPGym, MineSweeperMedium, gym envs, gymanx Bsuite. All fine.
- We've learned that I should not have made the default setting something that I never use day-to-day. Also, that MineSweeperMedium is a good test.

the end

