### PR TITLE
Module Actor/Critic Output Heads

### DIFF
--- a/amago/agent.py
+++ b/amago/agent.py
@@ -649,12 +649,14 @@ class Agent(nn.Module):
             ].sum()
 
         binary_filter = filter_ > 0
+        masked_logp_a = logp_a[mask.bool()]
         stats = {
-            "Minimum Action Logprob": logp_a.min(),
-            "Maximum Action Logprob": logp_a.max(),
+            "Minimum Action Logprob": masked_logp_a.min(),
+            "Maximum Action Logprob": masked_logp_a.max(),
+            "Mean Action Logprob": masked_logp_a.mean(),
             "Filter Max": filter_.max(),
             "Filter Min": filter_.min(),
-            "Filter Mean": filter_.mean(),
+            "Filter Mean": (mask * filter_).sum() / mask.sum(),
             "Pct. of Actions Approved by Binary FBC Filter (All Gammas)": utils.masked_avg(
                 binary_filter, mask
             )

--- a/amago/agent.py
+++ b/amago/agent.py
@@ -194,6 +194,8 @@ class Agent(nn.Module):
         use_target_actor: If True, use a target actor to sample actions used in TD targets.
             Defaults to True.
         use_multigamma: If True, train on multiple discount horizons (:py:class:`~amago.agent.Multigammas`) in parallel. Defaults to True.
+        actor_type: Actor MLP head for producing action distributions. Defaults to :py:class:`~amago.nets.actor_critic.Actor`.
+        critic_type: Critic MLP head for producing Q-values. Defaults to :py:class:`~amago.nets.actor_critic.NCritics`.
     """
 
     def __init__(
@@ -708,7 +710,7 @@ class MultiTaskAgent(Agent):
 
     The combination of points 2 and 3 stresses accurate advantage estimates and motivates a change
     in the default value of num_actions_for_value_in_critic_loss from 1 --> 3. Arguments otherwise
-    follow the information listed in amago.agent.Agent.
+    follow the information listed in :py:class:`~amago.agent.Agent`.
     """
 
     def __init__(

--- a/amago/experiment.py
+++ b/amago/experiment.py
@@ -916,7 +916,7 @@ class Experiment:
             "Unmasked Batch Size (in Timesteps)": unmasked_batch_size,
         } | update_info
 
-    def _get_grad_norms(self):
+    def get_grad_norms(self):
         """Get gradient norms for logging."""
         ggn = utils.get_grad_norm
         pi = self.policy
@@ -952,7 +952,7 @@ class Experiment:
                 if log_step:
                     l.update(
                         {"Learning Rate": self.lr_schedule.get_last_lr()[0]}
-                        | self._get_grad_norms()
+                        | self.get_grad_norms()
                     )
             self.optimizer.step()
             self.lr_schedule.step()

--- a/amago/nets/actor_critic.py
+++ b/amago/nets/actor_critic.py
@@ -4,6 +4,7 @@ Actor and critic output modules.
 
 from typing import Optional, Type
 from functools import lru_cache
+from abc import ABC, abstractmethod
 
 import torch
 from torch import nn
@@ -23,8 +24,58 @@ from amago.nets.policy_dists import (
 from amago.utils import amago_warning
 
 
+class BaseActorHead(nn.Module, ABC):
+    def __init__(
+        self,
+        state_dim: int,
+        action_dim: int,
+        discrete: bool,
+        gammas: torch.Tensor,
+        continuous_dist_type: Type[PolicyOutput],
+    ):
+        super().__init__()
+        self.state_dim = state_dim
+        self.action_dim = action_dim
+        self.discrete = discrete
+        self.gammas = gammas
+        self.num_gammas = len(self.gammas)
+        # determine policy output
+        dist_type = Discrete if self.discrete else continuous_dist_type
+        self.policy_dist = dist_type(d_action=self.action_dim)
+        assert isinstance(self.policy_dist, PolicyOutput)
+        assert self.policy_dist.is_discrete == self.discrete
+        self.actions_differentiable = self.policy_dist.actions_differentiable
+
+    def forward(
+        self, state: torch.Tensor, log_dict: Optional[dict] = None
+    ) -> pyd.Distribution:
+        """Compute an action distribution from a state representation.
+
+        Args:
+            state: The "state" sequence (the output of the TrajEncoder) (Batch, Length, state_dim)
+
+        Returns:
+            The action distribution. Type varies according to the output of `PolicyOutput`
+            (e.g. `Discrete` or `TanhGaussian`). Always a pytorch distribution (e.g., `Categorical`)
+            where sampled actions would have shape (Batch, Length, Gammas, action_dim).
+        """
+        dist_params = self.actor_network_forward(state=state, log_dict=log_dict)
+        assert dist_params.ndim == 4
+        assert dist_params.shape[-2:] == (
+            self.num_gammas,
+            self.policy_dist.input_dimension,
+        )
+        return self.policy_dist(dist_params, log_dict=log_dict)
+
+    @abstractmethod
+    def actor_network_forward(
+        self, state: torch.Tensor, log_dict: Optional[dict] = None
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+
 @gin.configurable
-class Actor(nn.Module):
+class Actor(BaseActorHead):
     """Actor output head architecture.
 
     A (small) MLP that maps the output of the TrajEncoder to a distribution over actions.
@@ -56,46 +107,31 @@ class Actor(nn.Module):
         dropout_p: float = 0.0,
         continuous_dist_type: Type[PolicyOutput] = TanhGaussian,
     ):
-        super().__init__()
-        # determine policy output
-        self.num_gammas = len(gammas)
-        dist_type = Discrete if discrete else continuous_dist_type
-        self.policy_dist = dist_type(d_action=action_dim)
-        assert isinstance(self.policy_dist, PolicyOutput)
-        assert self.policy_dist.is_discrete == discrete
-        self.actions_differentiable = self.policy_dist.actions_differentiable
-        d_output = self.policy_dist.input_dimension * self.num_gammas
-
+        super().__init__(
+            state_dim=state_dim,
+            action_dim=action_dim,
+            discrete=discrete,
+            gammas=gammas,
+            continuous_dist_type=continuous_dist_type,
+        )
         # build base network
         self.base = MLP(
             d_inp=state_dim,
             d_hidden=d_hidden,
             n_layers=n_layers,
-            d_output=d_output,
+            d_output=self.policy_dist.input_dimension * self.num_gammas,
             dropout_p=dropout_p,
             activation=activation,
         )
-        self.discrete = discrete
-        self.action_dim = action_dim
 
-    def forward(
+    def actor_network_forward(
         self, state: torch.Tensor, log_dict: Optional[dict] = None
-    ) -> pyd.Distribution:
-        """Compute an action distribution from a state representation.
-
-        Args:
-            state: The "state" sequence (the output of the TrajEncoder) (Batch, Length, state_dim)
-
-        Returns:
-            The action distribution. Type varies according to the output of `PolicyOutput`
-            (e.g. `Discrete` or `TanhGaussian`). Always a pytorch distribution (e.g., `Categorical`)
-            where sampled actions would have shape (Batch, Length, Gammas, action_dim).
-        """
+    ) -> torch.Tensor:
         dist_params = self.base(state)
         dist_params = rearrange(
             dist_params, "b ... (g f) -> b ... g f", g=self.num_gammas
         )
-        return self.policy_dist(dist_params, log_dict=log_dict)
+        return dist_params
 
 
 class _EinMixEnsemble(nn.Module):
@@ -159,8 +195,42 @@ def gammas_as_input_seq(
     return gammas_rep
 
 
+class BaseCriticHead(nn.Module, ABC):
+    def __init__(
+        self,
+        state_dim: int,
+        action_dim: int,
+        discrete: bool,
+        gammas: torch.Tensor,
+        num_critics: int,
+    ):
+        super().__init__()
+        self.state_dim = state_dim
+        self.action_dim = action_dim
+        self.discrete = discrete
+        self.gammas = gammas
+        self.num_gammas = len(self.gammas)
+        self.num_critics = num_critics
+
+    def forward(
+        self, state: torch.Tensor, action: torch.Tensor, log_dict: Optional[dict] = None
+    ) -> torch.Tensor:
+        assert state.ndim == 3
+        B, L, _ = state.shape
+        assert action.ndim == 5
+        K = action.shape[0]
+        out = self.critic_network_forward(state=state, action=action, log_dict=log_dict)
+        return out
+
+    @abstractmethod
+    def critic_network_forward(
+        self, state: torch.Tensor, action: torch.Tensor, log_dict: Optional[dict] = None
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+
 @gin.configurable
-class NCritics(nn.Module):
+class NCritics(BaseCriticHead):
     """Critic output head architecture.
 
     A (small) ensemble of MLPs that maps the state and action to a value estimate.
@@ -185,25 +255,27 @@ class NCritics(nn.Module):
         action_dim: int,
         discrete: bool,
         gammas: torch.Tensor,
-        num_critics: int = 4,
+        num_critics: int,
         d_hidden: int = 256,
         n_layers: int = 2,
         dropout_p: float = 0.0,
         activation: str = "leaky_relu",
     ):
-        super().__init__()
-        self.discrete = discrete
-        self.num_critics = num_critics
-        inp_dim = state_dim
-        self.num_gammas = len(gammas)
-        self.gammas = gammas
-        if not discrete:
-            inp_dim += action_dim + 1
+        super().__init__(
+            state_dim=state_dim,
+            action_dim=action_dim,
+            discrete=discrete,
+            gammas=gammas,
+            num_critics=num_critics,
+        )
+        inp_dim = self.state_dim
+        if not self.discrete:
+            inp_dim += self.action_dim + 1
             out_dim = 1
         else:
-            out_dim = self.num_gammas * action_dim
+            out_dim = self.num_gammas * self.action_dim
         self.net = _EinMixEnsemble(
-            ensemble_size=num_critics,
+            ensemble_size=self.num_critics,
             inp_dim=inp_dim,
             d_hidden=d_hidden,
             n_layers=n_layers,
@@ -216,7 +288,7 @@ class NCritics(nn.Module):
         return self.num_critics
 
     @torch.compile
-    def forward(
+    def critic_network_forward(
         self, state: torch.Tensor, action: torch.Tensor, log_dict: Optional[dict] = None
     ) -> torch.Tensor:
         """Compute a value estimate from a state and action.
@@ -231,7 +303,6 @@ class NCritics(nn.Module):
         Returns:
             The value estimate with shape (K, Batch, Length, num_critics, Gammas, 1).
         """
-        assert action.dim() == 5
         K, B, L, G, D = action.shape
         if self.discrete:
             assert K == 1
@@ -256,7 +327,7 @@ class NCritics(nn.Module):
 
 
 @gin.configurable
-class NCriticsTwoHot(nn.Module):
+class NCriticsTwoHot(BaseCriticHead):
     """Critic output head architecture.
 
     A (small) ensemble of MLPs that maps the state and action to a value estimate in the form
@@ -293,7 +364,8 @@ class NCriticsTwoHot(nn.Module):
         state_dim: int,
         action_dim: int,
         gammas: torch.Tensor,
-        num_critics: int = 4,
+        discrete: bool,
+        num_critics: int,
         d_hidden: int = 256,
         n_layers: int = 2,
         dropout_p: float = 0.0,
@@ -304,12 +376,14 @@ class NCriticsTwoHot(nn.Module):
         output_bins: int = 128,
         use_symlog: bool = True,
     ):
-        super().__init__()
-        self.num_critics = num_critics
-        self.num_gammas = len(gammas)
-        self.action_dim = action_dim
-        self.gammas = gammas
-        inp_dim = state_dim + action_dim + 1
+        super().__init__(
+            state_dim=state_dim,
+            action_dim=action_dim,
+            discrete=discrete,
+            gammas=gammas,
+            num_critics=num_critics,
+        )
+        inp_dim = self.state_dim + self.action_dim + 1
         out_dim = output_bins
         self.num_bins = output_bins
         if min_return is None or max_return is None:
@@ -327,7 +401,7 @@ class NCriticsTwoHot(nn.Module):
             output_bins,
         )
         self.net = _EinMixEnsemble(
-            ensemble_size=num_critics,
+            ensemble_size=self.num_critics,
             inp_dim=inp_dim,
             d_hidden=d_hidden,
             n_layers=n_layers,
@@ -340,7 +414,7 @@ class NCriticsTwoHot(nn.Module):
         return self.num_critics
 
     @torch.compile
-    def forward(
+    def critic_network_forward(
         self, state: torch.Tensor, action: torch.Tensor, log_dict: Optional[dict] = None
     ) -> pyd.Categorical:
         """Compute a categorical distribution over bins from a state and action.
@@ -355,7 +429,6 @@ class NCriticsTwoHot(nn.Module):
         Returns:
             The categorical distribution over bins with shape (K, Batch, Length, num_critics, output_bins).
         """
-        assert action.dim() == 5
         K, B, L, G, D = action.shape
         assert G == self.num_gammas
         state = repeat(state, "b l d -> (k b g) l d", k=K, g=self.num_gammas)

--- a/amago/nets/actor_critic.py
+++ b/amago/nets/actor_critic.py
@@ -309,9 +309,7 @@ class BaseCriticHead(nn.Module, ABC):
         self, state: torch.Tensor, action: torch.Tensor, log_dict: Optional[dict] = None
     ) -> torch.Tensor:
         assert state.ndim == 3
-        B, L, _ = state.shape
         assert action.ndim == 5
-        K = action.shape[0]
         out = self.critic_network_forward(state=state, action=action, log_dict=log_dict)
         return out
 

--- a/docs/tutorial/customization.rst
+++ b/docs/tutorial/customization.rst
@@ -107,6 +107,20 @@ RLDataset
 
 **Implement**: :py:class:`~amago.nets.policy_dists.PolicyOutput`
 
-**Substitute**: ``config = {"amago.nets.actor_critic.Actor.continuous_dist_type" : MyPolicyOutput, ...}; use_config(config); experiment = Experiment(...)``
+**Configure**: ``config = {"amago.nets.actor_critic.Actor.continuous_dist_type" : MyPolicyOutput, ...}; use_config(config); experiment = Experiment(...)``
 
 |
+
+Actor Output Head
+~~~~~~~~~~~~~~~~~~~
+**Implement** :py:class:`~amago.nets.actor_critic.BaseActorHead`
+
+**Configure**: ``Agent.actor_type : MyActor``
+
+|
+
+Critic Output Head
+~~~~~~~~~~~~~~~~~~~
+**Implement** : :py:class:`~amago.nets.actor_critic.BaseCriticHead`
+
+**Configure**: ``Agent.critic_type : MyCritic``

--- a/examples/00_meta_frozen_lake.py
+++ b/examples/00_meta_frozen_lake.py
@@ -1,8 +1,10 @@
+from argparse import ArgumentParser
+
 import amago
 from amago.envs.builtin.toy_gym import MetaFrozenLake
 from amago.envs import AMAGOEnv
 from amago.loading import DiskTrajDataset
-from amago.cli_utils import *
+from amago import cli_utils
 
 
 def add_cli(parser):
@@ -35,19 +37,19 @@ if __name__ == "__main__":
 
     config = {}
     # configure trajectory encoder (seq2seq memory model)
-    traj_encoder_type = switch_traj_encoder(
+    traj_encoder_type = cli_utils.switch_traj_encoder(
         config,
         arch=args.seq_model,
         memory_size=128,
         layers=3,
     )
     # configure timestep encoder
-    tstep_encoder_type = switch_tstep_encoder(
+    tstep_encoder_type = cli_utils.switch_tstep_encoder(
         config, arch="ff", n_layers=1, d_hidden=128, d_output=64, normalize_inputs=False
     )
 
     # we're using the default exploration strategy but being overly verbose about it for the example
-    exploration_wrapper_type = switch_exploration(
+    exploration_wrapper_type = cli_utils.switch_exploration(
         config,
         strategy="egreedy",
         eps_start=1.0,
@@ -55,7 +57,7 @@ if __name__ == "__main__":
         steps_anneal=1_000_000,
         randomize_eps=True,
     )
-    use_config(config)
+    cli_utils.use_config(config)
 
     group_name = f"{args.run_name}_{args.seq_model}"
     for trial in range(args.trials):

--- a/examples/01_basic_gym.py
+++ b/examples/01_basic_gym.py
@@ -5,7 +5,7 @@ import wandb
 
 import amago
 from amago.envs import AMAGOEnv
-from amago.cli_utils import *
+from amago import cli_utils
 
 
 def add_cli(parser):
@@ -26,7 +26,7 @@ def add_cli(parser):
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    add_common_cli(parser)
+    cli_utils.add_common_cli(parser)
     add_cli(parser)
     args = parser.parse_args()
 
@@ -43,24 +43,24 @@ if __name__ == "__main__":
         "amago.nets.policy_dists.Discrete.clip_prob_low": 1e-6,
     }
     # switch sequence model
-    traj_encoder_type = switch_traj_encoder(
+    traj_encoder_type = cli_utils.switch_traj_encoder(
         config,
         arch=args.traj_encoder,
         memory_size=args.memory_size,
         layers=args.memory_layers,
     )
     # switch agent
-    agent_type = switch_agent(
+    agent_type = cli_utils.switch_agent(
         config,
         args.agent_type,
         reward_multiplier=1.0,
     )
-    use_config(config, args.configs)
+    cli_utils.use_config(config, args.configs)
 
     group_name = f"{args.run_name}_{env_name}"
     for trial in range(args.trials):
         run_name = group_name + f"_trial_{trial}"
-        experiment = create_experiment_from_cli(
+        experiment = cli_utils.create_experiment_from_cli(
             args,
             make_train_env=make_train_env,
             make_val_env=make_train_env,
@@ -73,7 +73,7 @@ if __name__ == "__main__":
             group_name=group_name,
             val_timesteps_per_epoch=args.eval_timesteps,
         )
-        experiment = switch_async_mode(experiment, args.mode)
+        experiment = cli_utils.switch_async_mode(experiment, args.mode)
         experiment.start()
         if args.ckpt is not None:
             experiment.load_checkpoint(args.ckpt)

--- a/examples/06_alchemy.py
+++ b/examples/06_alchemy.py
@@ -4,30 +4,32 @@ import wandb
 
 from amago.envs import AMAGOEnv
 from amago.envs.builtin.alchemy import SymbolicAlchemy
-from amago.cli_utils import *
+from amago import cli_utils
 
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    add_common_cli(parser)
+    cli_utils.add_common_cli(parser)
     args = parser.parse_args()
 
     config = {}
-    traj_encoder_type = switch_traj_encoder(
+    traj_encoder_type = cli_utils.switch_traj_encoder(
         config,
         arch=args.traj_encoder,
         memory_size=args.memory_size,
         layers=args.memory_layers,
     )
-    exploration_wrapper_type = switch_exploration(
+    exploration_wrapper_type = cli_utils.switch_exploration(
         config, "bilevel", rollout_horizon=200, steps_anneal=2_500_000
     )
-    agent_type = switch_agent(config, args.agent_type, reward_multiplier=100.0)
-    tstep_encoder_type = switch_tstep_encoder(
+    agent_type = cli_utils.switch_agent(
+        config, args.agent_type, reward_multiplier=100.0
+    )
+    tstep_encoder_type = cli_utils.switch_tstep_encoder(
         config, arch="ff", n_layers=2, d_hidden=256, d_output=256
     )
 
-    use_config(config, args.configs)
+    cli_utils.use_config(config, args.configs)
     make_train_env = lambda: AMAGOEnv(
         env=SymbolicAlchemy(),
         env_name="dm_symbolic_alchemy",
@@ -35,7 +37,7 @@ if __name__ == "__main__":
     group_name = f"{args.run_name}_symbolic_dm_alchemy"
     for trial in range(args.trials):
         run_name = group_name + f"_trial_{trial}"
-        experiment = create_experiment_from_cli(
+        experiment = cli_utils.create_experiment_from_cli(
             args,
             make_train_env=make_train_env,
             make_val_env=make_train_env,
@@ -49,7 +51,7 @@ if __name__ == "__main__":
             agent_type=agent_type,
             val_timesteps_per_epoch=2000,
         )
-        switch_async_mode(experiment, args.mode)
+        experiment = cli_utils.switch_async_mode(experiment, args.mode)
         experiment.start()
         if args.ckpt is not None:
             experiment.load_checkpoint(args.ckpt)

--- a/examples/07_metaworld.py
+++ b/examples/07_metaworld.py
@@ -5,7 +5,7 @@ import wandb
 from amago.envs.builtin.metaworld_ml import Metaworld
 from amago.nets.tstep_encoders import FFTstepEncoder
 from amago.envs.exploration import BilevelEpsilonGreedy
-from amago.cli_utils import *
+from amago import cli_utils
 
 
 def add_cli(parser):
@@ -27,7 +27,7 @@ def add_cli(parser):
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    add_common_cli(parser)
+    cli_utils.add_common_cli(parser)
     add_cli(parser)
     args = parser.parse_args()
 
@@ -39,19 +39,19 @@ if __name__ == "__main__":
         "amago.nets.actor_critic.NCriticsTwoHot.max_return": 5000 * args.k,
         "amago.nets.actor_critic.NCriticsTwoHot.output_bins": 96,
     }
-    traj_encoder_type = switch_traj_encoder(
+    traj_encoder_type = cli_utils.switch_traj_encoder(
         config,
         arch=args.traj_encoder,
         memory_size=args.memory_size,
         layers=args.memory_layers,
     )
-    agent_type = switch_agent(
+    agent_type = cli_utils.switch_agent(
         config, args.agent_type, reward_multiplier=1.0, num_critics=4
     )
-    exploration_type = switch_exploration(
+    exploration_type = cli_utils.switch_exploration(
         config, "bilevel", steps_anneal=2_000_000, rollout_horizon=args.k * 500
     )
-    use_config(config, args.configs)
+    cli_utils.use_config(config, args.configs)
 
     make_train_env = lambda: Metaworld(args.benchmark, "train", k_episodes=args.k)
     make_test_env = lambda: Metaworld(args.benchmark, "test", k_episodes=args.k)
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     )
     for trial in range(args.trials):
         run_name = group_name + f"_trial_{trial}"
-        experiment = create_experiment_from_cli(
+        experiment = cli_utils.create_experiment_from_cli(
             args,
             make_train_env=make_train_env,
             make_val_env=make_train_env,
@@ -78,7 +78,7 @@ if __name__ == "__main__":
             exploration_wrapper_type=exploration_type,
         )
 
-        experiment = switch_async_mode(experiment, args.mode)
+        experiment = cli_utils.switch_async_mode(experiment, args.mode)
         experiment.start()
         if args.ckpt is not None:
             experiment.load_checkpoint(args.ckpt)

--- a/examples/09_multitask_procgen.py
+++ b/examples/09_multitask_procgen.py
@@ -8,7 +8,7 @@ from amago.envs.builtin.procgen_envs import (
     ALL_PROCGEN_GAMES,
 )
 from amago.nets.cnn import IMPALAishCNN
-from amago.cli_utils import *
+from amago import cli_utils
 
 
 def add_cli(parser):
@@ -43,26 +43,26 @@ PROCGEN_SETTINGS = {
 
 if __name__ == "__main__":
     parser = ArgumentParser()
+    cli_utils.add_common_cli(parser)
     add_cli(parser)
-    add_common_cli(parser)
     args = parser.parse_args()
 
     config = {}
-    traj_encoder_type = switch_traj_encoder(
+    traj_encoder_type = cli_utils.switch_traj_encoder(
         config,
         arch=args.traj_encoder,
         memory_size=args.memory_size,
         layers=args.memory_layers,
     )
-    tstep_encoder_type = switch_tstep_encoder(
+    tstep_encoder_type = cli_utils.switch_tstep_encoder(
         config,
         arch="cnn",
         cnn_type=IMPALAishCNN,
         channels_first=False,
         drqv2_aug=True,
     )
-    agent_type = switch_agent(config, args.agent_type)
-    use_config(config, args.configs)
+    agent_type = cli_utils.switch_agent(config, args.agent_type)
+    cli_utils.use_config(config, args.configs)
 
     procgen_kwargs = PROCGEN_SETTINGS[args.distribution]
     horizon = 2000 if "easy" in args.distribution else 5000
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     group_name = f"{args.run_name}_{args.distribution}_procgen_l_{args.max_seq_len}"
     for trial in range(args.trials):
         run_name = group_name + f"_trial_{trial}"
-        experiment = create_experiment_from_cli(
+        experiment = cli_utils.create_experiment_from_cli(
             args,
             make_train_env=make_train_env,
             make_val_env=make_test_env,
@@ -91,7 +91,7 @@ if __name__ == "__main__":
             group_name=group_name,
             val_timesteps_per_epoch=5 * horizon + 1,
         )
-        switch_async_mode(experiment, args.mode)
+        experiment = cli_utils.switch_async_mode(experiment, args.mode)
         experiment.start()
         if args.ckpt is not None:
             experiment.load_checkpoint(args.ckpt)

--- a/examples/10_babyai.py
+++ b/examples/10_babyai.py
@@ -12,7 +12,7 @@ from amago import TstepEncoder
 from amago.envs.builtin.babyai import MultitaskMetaBabyAI, ALL_BABYAI_TASKS
 from amago.envs import AMAGOEnv
 from amago.nets.utils import add_activation_log, symlog
-from amago.cli_utils import *
+from amago import cli_utils
 
 
 def add_cli(parser):
@@ -159,7 +159,7 @@ class BabyTstepEncoder(TstepEncoder):
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    add_common_cli(parser)
+    cli_utils.add_common_cli(parser)
     add_cli(parser)
     args = parser.parse_args()
 
@@ -169,15 +169,19 @@ if __name__ == "__main__":
         "amago.nets.actor_critic.NCriticsTwoHot.output_bins": 32,
         "BabyTstepEncoder.obs_kind": args.obs_kind,
     }
-    traj_encoder_type = switch_traj_encoder(
+    traj_encoder_type = cli_utils.switch_traj_encoder(
         config,
         arch=args.traj_encoder,
         memory_size=args.memory_size,
         layers=args.memory_layers,
     )
-    exploration_type = switch_exploration(config, "egreedy", steps_anneal=500_000)
-    agent_type = switch_agent(config, args.agent_type, reward_multiplier=1000.0)
-    use_config(config, args.configs)
+    exploration_type = cli_utils.switch_exploration(
+        config, "egreedy", steps_anneal=500_000
+    )
+    agent_type = cli_utils.switch_agent(
+        config, args.agent_type, reward_multiplier=1000.0
+    )
+    cli_utils.use_config(config, args.configs)
 
     make_train_env = lambda: BabyAIAMAGOEnv(
         MultitaskMetaBabyAI(
@@ -200,7 +204,7 @@ if __name__ == "__main__":
     group_name = f"{args.run_name}_babyai_{args.obs_kind}"
     for trial in range(args.trials):
         run_name = group_name + f"_trial_{trial}"
-        experiment = create_experiment_from_cli(
+        experiment = cli_utils.create_experiment_from_cli(
             args,
             make_train_env=make_train_env,
             make_val_env=make_val_env,
@@ -216,7 +220,7 @@ if __name__ == "__main__":
             val_timesteps_per_epoch=6000,
             save_trajs_as="npz",
         )
-        switch_async_mode(experiment, args.mode)
+        experiment = cli_utils.switch_async_mode(experiment, args.mode)
         experiment.start()
         if args.ckpt is not None:
             experiment.load_checkpoint(args.ckpt)

--- a/examples/11_xland_minigrid.py
+++ b/examples/11_xland_minigrid.py
@@ -15,7 +15,7 @@ import amago
 from amago.envs import AMAGOEnv
 from amago.envs.builtin.xland_minigrid import XLandMinigridVectorizedGym
 from amago.nets.utils import add_activation_log, symlog
-from amago.cli_utils import *
+from amago import cli_utils
 
 
 def add_cli(parser):
@@ -118,7 +118,7 @@ class XLandMGTstepEncoder(amago.TstepEncoder):
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    add_common_cli(parser)
+    cli_utils.add_common_cli(parser)
     add_cli(parser)
     args = parser.parse_args()
 
@@ -129,14 +129,14 @@ if __name__ == "__main__":
         "amago.nets.actor_critic.NCriticsTwoHot.output_bins": 32,
     }
 
-    traj_encoder_type = switch_traj_encoder(
+    traj_encoder_type = cli_utils.switch_traj_encoder(
         config,
         arch=args.traj_encoder,
         memory_size=args.memory_size,
         layers=args.memory_layers,
     )
-    agent_type = switch_agent(config, args.agent_type, reward_multiplier=10.0)
-    use_config(config, args.configs)
+    agent_type = cli_utils.switch_agent(config, args.agent_type, reward_multiplier=10.0)
+    cli_utils.use_config(config, args.configs)
 
     xland_kwargs = {
         "parallel_envs": args.parallel_actors,
@@ -162,7 +162,7 @@ if __name__ == "__main__":
 
     for trial in range(args.trials):
         run_name = group_name + f"_trial_{trial}"
-        experiment = create_experiment_from_cli(
+        experiment = cli_utils.create_experiment_from_cli(
             args,
             make_train_env=make_train_env,
             make_val_env=make_val_env,
@@ -178,7 +178,7 @@ if __name__ == "__main__":
             save_trajs_as="npz-compressed",
             grad_clip=2.0,
         )
-        switch_async_mode(experiment, args.mode)
+        experiment = cli_utils.switch_async_mode(experiment, args.mode)
         amago_device = experiment.DEVICE.index or torch.cuda.current_device()
         env_device = jax.devices("gpu")[amago_device]
         with jax.default_device(env_device):

--- a/examples/12_half_cheetah_vel.py
+++ b/examples/12_half_cheetah_vel.py
@@ -7,7 +7,7 @@ import wandb
 import amago
 from amago.envs import AMAGOEnv
 from amago.envs.builtin.half_cheetah_v4_vel import HalfCheetahV4_MetaVelocity
-from amago.cli_utils import *
+from amago import cli_utils
 
 
 def add_cli(parser):
@@ -82,7 +82,7 @@ class AMAGOEnvWithVelocityName(AMAGOEnv):
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    add_common_cli(parser)
+    cli_utils.add_common_cli(parser)
     add_cli(parser)
     args = parser.parse_args()
 
@@ -108,14 +108,14 @@ if __name__ == "__main__":
 
     config = {}
     # switch sequence model
-    traj_encoder_type = switch_traj_encoder(
+    traj_encoder_type = cli_utils.switch_traj_encoder(
         config,
         arch=args.traj_encoder,
         memory_size=args.memory_size,
         layers=args.memory_layers,
     )
     # switch agent
-    agent_type = switch_agent(
+    agent_type = cli_utils.switch_agent(
         config,
         args.agent_type,
         reward_multiplier=1.0,  # gym locomotion returns are already large
@@ -124,13 +124,15 @@ if __name__ == "__main__":
     )
     # "egreedy" exploration in continuous control is just the epsilon-scheduled random (normal)
     # noise from most TD3/DPPG implementations.
-    exploration_type = switch_exploration(config, "egreedy", steps_anneal=500_000)
-    use_config(config, args.configs)
+    exploration_type = cli_utils.switch_exploration(
+        config, "egreedy", steps_anneal=500_000
+    )
+    cli_utils.use_config(config, args.configs)
 
     group_name = args.run_name
     for trial in range(args.trials):
         run_name = group_name + f"_trial_{trial}"
-        experiment = create_experiment_from_cli(
+        experiment = cli_utils.create_experiment_from_cli(
             args,
             make_train_env=make_train_env,  # different train/val envs
             make_val_env=make_val_env,

--- a/examples/13_mazerunner_relabeling.py
+++ b/examples/13_mazerunner_relabeling.py
@@ -3,7 +3,7 @@ A demonstration of the hindsight instruction relabeling techinque discussed in t
 a generalization of Hindsight Experience Replay (HER) to sequences of multiple goals.
 The ability to relabel data is another good reason to prefer off-policy RL^2 to on-policy.
 
-This example uses the "MazeRunner" environment. MazeRunner is an adapted version of Memory Maze 
+This example uses the "MazeRunner" environment. MazeRunner is an adapted version of Memory Maze
 (https://arxiv.org/abs/2210.13383) that does not require the DM Lab simulator or learning from pixels.
 For more information please refer to the AMAGO Appendix C.4.
 
@@ -11,7 +11,7 @@ There are three steps to using hindsight relabeling:
 
 1. Make the env's observations a dict with keys for the intended goal and alternative goals achieved
    at that timestep. Goals are often subsets of the state space. In this example, observations consist of:
-   
+
    `obs` : the regular observation from the maze environment (LIDAR-ish depth sensors to the walls, timer, etc.)
    `goals` : a sequence of k goal positions to navigate to.
    `achieved`: the agent's current position.
@@ -33,7 +33,7 @@ import amago
 from amago.envs.builtin.mazerunner import MazeRunnerAMAGOEnv
 from amago.hindsight import Relabeler, FrozenTraj
 from amago.loading import DiskTrajDataset
-from amago.cli_utils import *
+from amago import cli_utils
 
 
 def add_cli(parser):
@@ -175,7 +175,7 @@ class HindsightInstructionReplay(Relabeler):
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    add_common_cli(parser)
+    cli_utils.add_common_cli(parser)
     add_cli(parser)
     args = parser.parse_args()
 
@@ -189,19 +189,19 @@ if __name__ == "__main__":
     )
     config = {}
     # switch sequence model
-    traj_encoder_type = switch_traj_encoder(
+    traj_encoder_type = cli_utils.switch_traj_encoder(
         config,
         arch=args.traj_encoder,
         memory_size=args.memory_size,
         layers=args.memory_layers,
     )
     # switch agent
-    agent_type = switch_agent(
+    agent_type = cli_utils.switch_agent(
         config,
         args.agent_type,
         # reward_multiplier=100.,
     )
-    tstep_encoder_type = switch_tstep_encoder(
+    tstep_encoder_type = cli_utils.switch_tstep_encoder(
         config,
         arch="ff",
         n_layers=2,
@@ -209,12 +209,12 @@ if __name__ == "__main__":
         # ignore "achieved" obs dict in the policy net.
         specify_obs_keys=["obs", "goals"],
     )
-    exploration_type = switch_exploration(
+    exploration_type = cli_utils.switch_exploration(
         config,
         strategy="egreedy",
         steps_anneal=500_000,  # needs re-tuning; paper used an older version
     )
-    use_config(config, args.configs)
+    cli_utils.use_config(config, args.configs)
 
     group_name = args.run_name
     for trial in range(args.trials):
@@ -230,7 +230,7 @@ if __name__ == "__main__":
             ),
         )
 
-        experiment = create_experiment_from_cli(
+        experiment = cli_utils.create_experiment_from_cli(
             args,
             make_train_env=make_train_env,
             make_val_env=make_train_env,
@@ -250,7 +250,7 @@ if __name__ == "__main__":
             group_name=group_name,
             val_timesteps_per_epoch=args.time_limit * 5,
         )
-        experiment = switch_async_mode(experiment, args.mode)
+        experiment = cli_utils.switch_async_mode(experiment, args.mode)
         experiment.start()
         if args.ckpt is not None:
             experiment.load_checkpoint(args.ckpt)

--- a/examples/14_d4rl.py
+++ b/examples/14_d4rl.py
@@ -13,6 +13,7 @@ from amago.envs import AMAGOEnv
 from amago.cli_utils import *
 from amago.loading import RLData, RLDataset
 from amago.nets.policy_dists import TanhGaussian, GMM, Beta
+from amago.nets.actor_critic import ResidualActor, Actor
 
 
 def add_cli(parser):
@@ -28,6 +29,13 @@ def add_cli(parser):
         default="TanhGaussian",
         help="Policy distribution type",
         choices=["TanhGaussian", "GMM", "Beta"],
+    )
+    parser.add_argument(
+        "--actor_type",
+        type=str,
+        default="Actor",
+        help="Actor head type",
+        choices=["ResidualActor", "Actor"],
     )
     parser.add_argument(
         "--eval_timesteps",
@@ -162,6 +170,10 @@ if __name__ == "__main__":
         "amago.nets.actor_critic.NCriticsTwoHot.output_bins": 128,
         "amago.nets.actor_critic.Actor.d_hidden": 128,
         "amago.nets.actor_critic.Actor.continuous_dist_type": eval(args.policy_dist),
+        "amago.nets.actor_critic.ResidualActor.feature_dim": 128,
+        "amago.nets.actor_critic.ResidualActor.residual_ff_dim": 256,
+        "amago.nets.actor_critic.ResidualActor.residual_blocks": 2,
+        "amago.nets.actor_critic.ResidualActor.continuous_dist_type": eval(args.policy_dist),
     }
     tstep_encoder_type = switch_tstep_encoder(
         config,
@@ -186,6 +198,7 @@ if __name__ == "__main__":
         num_actions_for_value_in_critic_loss=2,
         num_actions_for_value_in_actor_loss=4,
         num_critics=4,
+        actor_type=eval(args.actor_type),
     )
     use_config(config, args.configs)
 

--- a/examples/14_d4rl.py
+++ b/examples/14_d4rl.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import amago
 from amago.envs import AMAGOEnv
-from amago.cli_utils import *
+from amago import cli_utils
 from amago.loading import RLData, RLDataset
 from amago.nets.policy_dists import TanhGaussian, GMM, Beta
 from amago.nets.actor_critic import ResidualActor, Actor
@@ -138,7 +138,7 @@ class D4RLGymEnv(gym.Env):
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    add_common_cli(parser)
+    cli_utils.add_common_cli(parser)
     add_cli(parser)
     args = parser.parse_args()
 
@@ -173,22 +173,24 @@ if __name__ == "__main__":
         "amago.nets.actor_critic.ResidualActor.feature_dim": 128,
         "amago.nets.actor_critic.ResidualActor.residual_ff_dim": 256,
         "amago.nets.actor_critic.ResidualActor.residual_blocks": 2,
-        "amago.nets.actor_critic.ResidualActor.continuous_dist_type": eval(args.policy_dist),
+        "amago.nets.actor_critic.ResidualActor.continuous_dist_type": eval(
+            args.policy_dist
+        ),
     }
-    tstep_encoder_type = switch_tstep_encoder(
+    tstep_encoder_type = cli_utils.switch_tstep_encoder(
         config,
         arch="ff",
         d_hidden=128,
         d_output=128,
         n_layers=1,
     )
-    traj_encoder_type = switch_traj_encoder(
+    traj_encoder_type = cli_utils.switch_traj_encoder(
         config,
         arch=args.traj_encoder,
         memory_size=args.memory_size,
         layers=args.memory_layers,
     )
-    agent_type = switch_agent(
+    agent_type = cli_utils.switch_agent(
         config,
         args.agent_type,
         online_coeff=0.0,
@@ -200,12 +202,12 @@ if __name__ == "__main__":
         num_critics=4,
         actor_type=eval(args.actor_type),
     )
-    use_config(config, args.configs)
+    cli_utils.use_config(config, args.configs)
 
     group_name = f"{args.run_name}_{env_name}"
     for trial in range(args.trials):
         run_name = group_name + f"_trial_{trial}"
-        experiment = create_experiment_from_cli(
+        experiment = cli_utils.create_experiment_from_cli(
             args,
             make_train_env=make_train_env,
             make_val_env=make_train_env,
@@ -221,7 +223,7 @@ if __name__ == "__main__":
             padded_sampling="right",
             sample_actions=False,
         )
-        experiment = switch_async_mode(experiment, args.mode)
+        experiment = cli_utils.switch_async_mode(experiment, args.mode)
         experiment.start()
         if args.ckpt is not None:
             experiment.load_checkpoint(args.ckpt)


### PR DESCRIPTION
Makes the actor and critic MLPs at the end of the traj encoder swappable by inheritance similar to every other part of the network.